### PR TITLE
Rename Mastermind puzzle to Control Unlock

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Perfect for classrooms, puzzle hunts, D&D campaigns, or digital escape rooms.
 
 | Puzzle                | Theme                       | Mechanics                       |
 |----------------------|-----------------------------|----------------------------------|
-| ⚓ Mastermind Code    | Submarine Lock System       | Classic codebreaking logic       |
+| ⚓ Control Unlock     | Submarine Lock System       | Classic codebreaking logic       |
 | 🔍 Porthole Puzzle    | Visual Identification       | Spot the difference              |
 | ⚖️ Ballast Balance    | Sub-level Control Mechanism | Math/weight distribution puzzle  |
 | 📡 Sonar Shapes       | Navigation Grid Mapping     | Pattern recognition + logic grid |
@@ -45,7 +45,7 @@ Each puzzle reveals a **nautical keyword** like `RUDDER`, `PERISCOPE`, or `HELM`
 /nautical-puzzle-hub/
 ├── index.html          # Main entrypoint with puzzle tabs
 ├── style.css           # Global visual styling
-├── mastermind.js       # Logic for Mastermind Code
+├── control-unlock.js   # Logic for Control Unlock puzzle
 ├── porthole.js         # Logic for Spot-the-Difference
 ├── ballast.js          # Logic for Ballast math puzzle
 ├── sonar.js            # Logic for sonar pattern puzzle
@@ -115,6 +115,6 @@ To deploy:
 
 ## 💡 Inspirations
 
-- Classic [Mastermind](https://en.wikipedia.org/wiki/Mastermind_(board_game)) and logic puzzles
+- Classic codebreaking logic puzzles (e.g., [this board game](https://en.wikipedia.org/wiki/Mastermind_(board_game)))
 - Submarine tropes from *Crimson Tide*, *Hunt for Red October*, *20,000 Leagues Under the Sea*
 - Old-school educational games and escape rooms

--- a/control-unlock.js
+++ b/control-unlock.js
@@ -129,7 +129,7 @@ function resetGame() {
   devOutput.textContent = '';
 
   puzzleBox.innerHTML = `
-    <h2>⚓ Mastermind Code</h2>
+    <h2>⚓ Control Unlock</h2>
     <p>Guess the hidden 4-color signal used by the submarine crew to unlock the vault. You have 10 tries to break the code!</p>
     <div class="board" id="board"></div>
     <div class="color-picker" id="color-picker"></div>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
   </header>
   <nav>
     <div id="keyword-banner"></div>
-    <button class="tab" data-target="mastermind">⚓ Mastermind Code</button>
+    <button class="tab" data-target="control-unlock">⚓ Control Unlock</button>
     <button class="tab" data-target="spot-diff">🔍 Porthole Puzzle</button>
     <button class="tab" data-target="ballast">⚖️ Ballast Balance</button>
     <button class="tab" data-target="sonar">📡 Sonar Shapes</button>
@@ -26,15 +26,15 @@
     <div id="dev-output"></div>
   </div>
 
-  <section id="mastermind" class="active">
+  <section id="control-unlock" class="active">
     <div class="content-box" id="puzzle-box">
-      <h2>⚓ Mastermind Code</h2>
+      <h2>⚓ Control Unlock</h2>
       <p>Guess the hidden 4-color signal used by the submarine crew to unlock the vault. You have 10 tries to break the code!</p>
       <div class="board" id="board"></div>
       <div class="color-picker" id="color-picker"></div>
     </div>
   </section>
 
-  <script src="mastermind.js"></script>
+  <script src="control-unlock.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- rename the Mastermind puzzle tab and heading to "Control Unlock"
- update the game reset logic to rebuild the UI with the new puzzle title
- refresh the documentation and file references to match the Control Unlock naming

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d07cb7c3608325b421036d43624814