### PR TITLE
Add ballast balance puzzle interface

### DIFF
--- a/control-unlock.js
+++ b/control-unlock.js
@@ -8,10 +8,54 @@ let currentRow = 0;
 
 let board = null;
 let colorPicker = null;
+
 const devOutput = document.getElementById('dev-output');
 const devTools = document.getElementById('dev-tools');
 const keywordBanner = document.getElementById('keyword-banner');
 const puzzleBox = document.getElementById('puzzle-box');
+
+const ballastConfig = {
+  baseTilt: -10,
+  baseDepth: -8,
+  maxMoves: 7,
+  gaugeRange: 18,
+  gaugeDegrees: 65,
+  keyword: 'TRIM',
+};
+
+const ballastLevers = [
+  { id: 'bow', label: 'Bow Flood', tilt: -3, depth: 4 },
+  { id: 'stern', label: 'Stern Pumps', tilt: 4, depth: -3 },
+  { id: 'port', label: 'Port Trim', tilt: -5, depth: -2 },
+  { id: 'starboard', label: 'Starboard Trim', tilt: 6, depth: 5 },
+];
+
+const ballastState = {
+  polarity: 1,
+  movesRemaining: ballastConfig.maxMoves,
+  locked: false,
+};
+
+let ballastLastResult = {
+  tilt: ballastConfig.baseTilt,
+  depth: ballastConfig.baseDepth,
+};
+
+const ballastElements = {
+  panel: null,
+  status: null,
+  outcome: null,
+  digital: null,
+  moves: null,
+  toggleButton: null,
+  confirmButton: null,
+  resetButton: null,
+  tiltNeedle: null,
+  tiltReadout: null,
+  depthNeedle: null,
+  depthReadout: null,
+  levers: [],
+};
 
 function generateSolution() {
   return Array.from({ length: 4 }, () => colors[Math.floor(Math.random() * colors.length)]);
@@ -22,6 +66,7 @@ function randomKeyword() {
 }
 
 function renderBoard() {
+  if (!board) return;
   board.innerHTML = '';
   guesses.forEach((guess, index) => {
     if (keywordBanner.style.display === 'block' && index > currentRow) return;
@@ -56,7 +101,7 @@ function renderBoard() {
 }
 
 function checkGuess() {
-  let guess = guesses[currentRow];
+  const guess = guesses[currentRow];
   let black = 0;
   let white = 0;
   const solutionCopy = [...solution];
@@ -87,11 +132,18 @@ function checkGuess() {
     puzzleBox.innerHTML = `<h2>✅ Code Cracked!</h2>
       <p style='font-size:1.2rem;'>The final code was:</p>
       <div style='display:flex; justify-content:center; gap:1rem; margin-bottom: 1rem;'>
-        ${solution.map(color => `<div style='width:2rem; height:2rem; border-radius:50%; background:${color}; border:2px solid #fff;'></div>`).join('')}
+        ${solution
+          .map(
+            color =>
+              `<div style='width:2rem; height:2rem; border-radius:50%; background:${color}; border:2px solid #fff;'></div>`
+          )
+          .join('')}
       </div>
       <p style='margin-top:1rem; font-size:2rem; font-weight:bold; text-align:center; color:#90e0ef;'>🔓 ${keyword}</p>`;
     return;
-  } else if (currentRow === 9) {
+  }
+
+  if (currentRow === guesses.length - 1) {
     alert(`💥 Game over! The correct code was: ${solution.join(', ')}`);
   }
 
@@ -100,6 +152,7 @@ function checkGuess() {
 }
 
 function handleColorClick(color) {
+  if (keywordBanner.style.display === 'block') return;
   if (guesses[currentRow].length < 4) {
     guesses[currentRow].push(color);
     renderBoard();
@@ -110,6 +163,7 @@ function handleColorClick(color) {
 }
 
 function renderColorPicker() {
+  if (!colorPicker) return;
   colorPicker.innerHTML = '';
   colors.forEach(color => {
     const peg = document.createElement('div');
@@ -120,14 +174,46 @@ function renderColorPicker() {
   });
 }
 
-function resetGame() {
-  solution = generateSolution();
+function setupTabs() {
+  const buttons = Array.from(document.querySelectorAll('nav .tab'));
+  const sections = Array.from(document.querySelectorAll('section'));
+  const defaultSection = document.querySelector('section.active');
+  const defaultId = defaultSection ? defaultSection.id : sections[0]?.id;
+
+  buttons.forEach(button => {
+    button.addEventListener('click', () => activateTab(button.dataset.target));
+  });
+
+  if (defaultId) {
+    activateTab(defaultId);
+  }
+}
+
+function activateTab(targetId) {
+  const buttons = Array.from(document.querySelectorAll('nav .tab'));
+  const sections = Array.from(document.querySelectorAll('section'));
+
+  buttons.forEach(button => {
+    button.classList.toggle('active', button.dataset.target === targetId);
+  });
+
+  sections.forEach(section => {
+    section.classList.toggle('active', section.id === targetId);
+  });
+}
+
+function initializeControlUnlock() {
+  board = document.getElementById('board');
+  colorPicker = document.getElementById('color-picker');
   guesses = Array.from({ length: 10 }, () => []);
   scores = Array.from({ length: 10 }, () => ({ black: 0, white: 0 }));
   currentRow = 0;
-  keywordBanner.style.display = 'none';
-  devOutput.textContent = '';
+  solution = generateSolution();
+  renderColorPicker();
+  renderBoard();
+}
 
+function resetControlUnlockPuzzle() {
   puzzleBox.innerHTML = `
     <h2>⚓ Control Unlock</h2>
     <p>Guess the hidden 4-color signal used by the submarine crew to unlock the vault. You have 10 tries to break the code!</p>
@@ -135,28 +221,350 @@ function resetGame() {
     <div class="color-picker" id="color-picker"></div>
   `;
 
-  // Wait for DOM rebuild
-  setTimeout(() => {
-    board = document.getElementById('board');
-    colorPicker = document.getElementById('color-picker');
-    renderColorPicker();
-    renderBoard();
-  }, 50);
+  setTimeout(initializeControlUnlock, 50);
+}
+
+function initializeBallastPuzzle() {
+  ballastElements.panel = document.getElementById('ballast-panel');
+  ballastElements.status = document.getElementById('ballast-status');
+  ballastElements.outcome = document.getElementById('ballast-outcome');
+  ballastElements.digital = document.getElementById('ballast-digital');
+  ballastElements.moves = document.getElementById('ballast-moves');
+  ballastElements.toggleButton = document.getElementById('ballast-polarity');
+  ballastElements.confirmButton = document.getElementById('ballast-confirm');
+  ballastElements.resetButton = document.getElementById('ballast-reset');
+  ballastElements.tiltNeedle = document.querySelector('.tilt-gauge .needle');
+  ballastElements.tiltReadout = document.getElementById('ballast-tilt-readout');
+  ballastElements.depthNeedle = document.querySelector('.depth-gauge .needle');
+  ballastElements.depthReadout = document.getElementById('ballast-depth-readout');
+
+  const sliderNodes = Array.from(
+    document.querySelectorAll('.ballast-lever input[type="range"]')
+  );
+  ballastElements.levers = sliderNodes
+    .map(slider => {
+      const wrapper = slider.closest('.ballast-lever');
+      if (!wrapper) return null;
+      const leverId = wrapper.dataset.lever;
+      const config = ballastLevers.find(lever => lever.id === leverId);
+      if (!config) return null;
+      const valueDisplay = wrapper.querySelector('.lever-value');
+      return { slider, valueDisplay, config };
+    })
+    .filter(Boolean);
+
+  ballastElements.levers.forEach(({ slider }) => {
+    slider.addEventListener('input', () => {
+      updateBallastValueDisplays();
+      showPendingBallastMessage();
+    });
+  });
+
+  ballastElements.toggleButton?.addEventListener('click', toggleBallastPolarity);
+  ballastElements.confirmButton?.addEventListener('click', commitBallastAdjustment);
+  ballastElements.resetButton?.addEventListener('click', resetBallastPuzzle);
+
+  resetBallastPuzzle();
+}
+
+function resetBallastPuzzle() {
+  ballastState.polarity = 1;
+  ballastState.movesRemaining = ballastConfig.maxMoves;
+  ballastState.locked = false;
+  ballastLastResult = {
+    tilt: ballastConfig.baseTilt,
+    depth: ballastConfig.baseDepth,
+  };
+
+  ballastElements.levers.forEach(({ slider }) => {
+    slider.value = '2';
+    slider.disabled = false;
+  });
+
+  ballastElements.toggleButton && (ballastElements.toggleButton.disabled = false);
+  ballastElements.confirmButton && (ballastElements.confirmButton.disabled = false);
+
+  updateBallastPolarity();
+  updateBallastValueDisplays();
+  refreshBallastDisplays(ballastLastResult);
+  updateBallastMoves();
+
+  if (ballastElements.outcome) {
+    ballastElements.outcome.textContent = '';
+    ballastElements.outcome.className = 'ballast-outcome';
+  }
+}
+
+function toggleBallastPolarity() {
+  if (ballastState.locked) return;
+  ballastState.polarity *= -1;
+  updateBallastPolarity();
+  showPendingBallastMessage();
+}
+
+function updateBallastPolarity() {
+  if (!ballastElements.toggleButton) return;
+  if (ballastState.polarity === 1) {
+    ballastElements.toggleButton.textContent = 'Polarity: Flood Tanks';
+    ballastElements.toggleButton.classList.remove('venting');
+  } else {
+    ballastElements.toggleButton.textContent = 'Polarity: Vent Tanks';
+    ballastElements.toggleButton.classList.add('venting');
+  }
+}
+
+function updateBallastValueDisplays() {
+  ballastElements.levers.forEach(({ slider, valueDisplay }) => {
+    if (!valueDisplay) return;
+    const offset = parseInt(slider.value, 10) - 2;
+    valueDisplay.textContent = offset > 0 ? `+${offset}` : `${offset}`;
+  });
+}
+
+function showPendingBallastMessage() {
+  if (ballastState.locked) return;
+  if (!ballastElements.status || !ballastElements.panel) return;
+  const descriptor = describeBallastResult(ballastLastResult);
+  const pendingLevel = descriptor.level === 'stable' ? 'caution' : descriptor.level;
+  applyBallastStatus(
+    `${descriptor.message} Adjustments primed—confirm to engage the ballast tanks.`,
+    pendingLevel
+  );
+}
+
+function evaluateBallastState() {
+  let tilt = ballastConfig.baseTilt;
+  let depth = ballastConfig.baseDepth;
+
+  ballastElements.levers.forEach(({ slider, config }) => {
+    const offset = parseInt(slider.value, 10) - 2;
+    tilt += ballastState.polarity * offset * config.tilt;
+    depth += ballastState.polarity * offset * config.depth;
+  });
+
+  return { tilt, depth };
+}
+
+function refreshBallastDisplays(result) {
+  const descriptor = describeBallastResult(result);
+  updateBallastReadouts(result);
+  updateBallastDigital(result, descriptor.level);
+  applyBallastStatus(descriptor.message, descriptor.level);
+  return descriptor;
+}
+
+function updateBallastReadouts(result) {
+  if (!ballastElements.tiltNeedle || !ballastElements.depthNeedle) return;
+  const { tilt, depth } = result;
+  const tiltAngle = mapToGauge(tilt, ballastConfig.gaugeRange, ballastConfig.gaugeDegrees);
+  const depthAngle = mapToGauge(depth, ballastConfig.gaugeRange, ballastConfig.gaugeDegrees);
+
+  ballastElements.tiltNeedle.style.transform = `rotate(${tiltAngle}deg)`;
+  ballastElements.depthNeedle.style.transform = `rotate(${depthAngle}deg)`;
+
+  if (ballastElements.tiltReadout) {
+    ballastElements.tiltReadout.textContent = formatTiltReadout(tilt);
+  }
+
+  if (ballastElements.depthReadout) {
+    ballastElements.depthReadout.textContent = formatDepthReadout(depth);
+  }
+}
+
+function mapToGauge(value, maxValue, maxDegrees) {
+  const limit = Math.max(1, maxValue);
+  const clamped = Math.max(-limit, Math.min(limit, value));
+  return (clamped / limit) * maxDegrees;
+}
+
+function formatTiltReadout(tilt) {
+  if (tilt === 0) return 'Level Trim';
+  const direction = tilt < 0 ? 'Port' : 'Starboard';
+  return `${Math.abs(tilt)}° ${direction}`;
+}
+
+function formatDepthReadout(depth) {
+  if (depth === 0) return 'Neutral Buoyancy';
+  const direction = depth < 0 ? 'Rising' : 'Sinking';
+  return `${Math.abs(depth)}m ${direction}`;
+}
+
+function updateBallastDigital(result, level) {
+  if (!ballastElements.digital) return;
+  const severity = Math.abs(result.tilt) * 4 + Math.abs(result.depth) * 3;
+  const score = Math.max(0, 100 - severity * 2);
+  ballastElements.digital.textContent = `Stability score: ${score.toString().padStart(3, '0')}`;
+  ballastElements.digital.dataset.level = level;
+}
+
+function describeBallastResult({ tilt, depth }) {
+  const lines = [];
+
+  if (tilt === 0) {
+    lines.push('Trim level across port and starboard.');
+  } else if (tilt < 0) {
+    lines.push(`Tilting ${Math.abs(tilt)}° to the port side.`);
+  } else {
+    lines.push(`Tilting ${Math.abs(tilt)}° to the starboard side.`);
+  }
+
+  if (depth === 0) {
+    lines.push('Depth locked at neutral buoyancy.');
+  } else if (depth < 0) {
+    lines.push(`Ballast too light — rising ${Math.abs(depth)}m.`);
+  } else {
+    lines.push(`Ballast heavy — sinking ${Math.abs(depth)}m.`);
+  }
+
+  const severity = Math.max(Math.abs(tilt), Math.abs(depth));
+  let level = 'danger';
+
+  if (severity === 0) {
+    level = 'stable';
+    lines.push('Creaks fade as the hull steadies. Lights glow green.');
+  } else if (severity <= 3) {
+    level = 'caution';
+    lines.push('Pipes groan, but gauges hover near center.');
+  } else {
+    lines.push('Alarm lamps flash crimson; water sloshes through the tanks.');
+  }
+
+  return { message: lines.join(' '), level };
+}
+
+function applyBallastStatus(message, level) {
+  if (!ballastElements.status || !ballastElements.panel) return;
+  ballastElements.status.textContent = message;
+  ballastElements.status.className = `ballast-status ${level}`;
+  ballastElements.panel.classList.remove('ballast-stable', 'ballast-caution', 'ballast-danger');
+  ballastElements.panel.classList.add(`ballast-${level}`);
+}
+
+function updateBallastMoves() {
+  if (ballastElements.moves) {
+    ballastElements.moves.textContent = ballastState.movesRemaining;
+  }
+}
+
+function commitBallastAdjustment() {
+  if (ballastState.locked || ballastState.movesRemaining <= 0) return;
+  ballastState.movesRemaining -= 1;
+  const result = evaluateBallastState();
+  ballastLastResult = result;
+  const descriptor = refreshBallastDisplays(result);
+  updateBallastMoves();
+
+  if (result.tilt === 0 && result.depth === 0) {
+    handleBallastSuccess();
+    return;
+  }
+
+  if (ballastState.movesRemaining === 0) {
+    handleBallastFailure(descriptor);
+  }
+}
+
+function handleBallastSuccess() {
+  ballastState.locked = true;
+  lockBallastInputs();
+
+  if (ballastElements.outcome) {
+    ballastElements.outcome.textContent = `Systems balanced — keyword ${ballastConfig.keyword}`;
+    ballastElements.outcome.className = 'ballast-outcome success';
+  }
+
+  keywordBanner.textContent = `⚖️ ${ballastConfig.keyword} SECURED`;
+  keywordBanner.style.display = 'block';
+}
+
+function handleBallastFailure(descriptor) {
+  ballastState.locked = true;
+  lockBallastInputs();
+
+  if (ballastElements.outcome) {
+    ballastElements.outcome.textContent = 'Pressure hull breach imminent — reset required.';
+    ballastElements.outcome.className = 'ballast-outcome failure';
+  }
+
+  if (descriptor.level !== 'danger') {
+    applyBallastStatus(
+      `${descriptor.message} Red alarms pulse as the ballast system locks out.`,
+      'danger'
+    );
+  }
+}
+
+function lockBallastInputs() {
+  ballastElements.levers.forEach(({ slider }) => {
+    slider.disabled = true;
+  });
+
+  if (ballastElements.toggleButton) {
+    ballastElements.toggleButton.disabled = true;
+  }
+
+  if (ballastElements.confirmButton) {
+    ballastElements.confirmButton.disabled = true;
+  }
+}
+
+function resetGame() {
+  keywordBanner.style.display = 'none';
+  keywordBanner.textContent = '';
+  devOutput.textContent = '';
+  resetControlUnlockPuzzle();
+  resetBallastPuzzle();
 }
 
 function revealSolution() {
-  devOutput.textContent = `🔐 Current Code: ${solution.join(', ')}`;
+  const controlSolution = solution ? solution.join(', ') : 'Not initialised';
+  const ballastSolutions = findBallastSolutions();
+  const ballastHint = ballastSolutions.length
+    ? ballastSolutions
+        .map(offsets =>
+          offsets
+            .map((value, index) => {
+              const label = ballastLevers[index].label;
+              return `${label}: ${value >= 0 ? '+' : ''}${value}`;
+            })
+            .join(' | ')
+        )
+        .join('  •  ')
+    : 'No neutral combination found.';
+
+  devOutput.innerHTML = `🔐 Current Code: ${controlSolution}<br>⚖️ Ballast Offsets (flood polarity): ${ballastHint}`;
+}
+
+function findBallastSolutions() {
+  const combos = [];
+  for (let a = -2; a <= 2; a++) {
+    for (let b = -2; b <= 2; b++) {
+      for (let c = -2; c <= 2; c++) {
+        for (let d = -2; d <= 2; d++) {
+          const offsets = [a, b, c, d];
+          let tilt = ballastConfig.baseTilt;
+          let depth = ballastConfig.baseDepth;
+          offsets.forEach((offset, index) => {
+            const lever = ballastLevers[index];
+            tilt += offset * lever.tilt;
+            depth += offset * lever.depth;
+          });
+          if (tilt === 0 && depth === 0) {
+            combos.push(offsets);
+          }
+        }
+      }
+    }
+  }
+  return combos;
 }
 
 function toggleDevTools() {
   devTools.style.display = devTools.style.display === 'none' ? 'block' : 'none';
 }
 
-// Init
 window.addEventListener('DOMContentLoaded', () => {
-  board = document.getElementById('board');
-  colorPicker = document.getElementById('color-picker');
-  solution = generateSolution();
-  renderColorPicker();
-  renderBoard();
+  setupTabs();
+  initializeControlUnlock();
+  initializeBallastPuzzle();
 });

--- a/index.html
+++ b/index.html
@@ -35,6 +35,107 @@
     </div>
   </section>
 
+  <section id="spot-diff">
+    <div class="content-box placeholder">
+      <h2>🔍 Porthole Puzzle</h2>
+      <p>The porthole display is still calibrating. Check back soon for this challenge.</p>
+    </div>
+  </section>
+
+  <section id="ballast">
+    <div class="content-box ballast-panel" id="ballast-panel">
+      <div>
+        <h2>⚖️ Ballast Balance</h2>
+        <p>Trim the submarine by tuning the ballast levers. Use the polarity switch to vent or flood tanks, then lock in your adjustments before alarms overwhelm the crew.</p>
+      </div>
+      <div class="ballast-body">
+        <div class="ballast-controls">
+          <div class="lever-bank">
+            <div class="ballast-lever" data-lever="bow">
+              <div class="lever-title">Bow Flood</div>
+              <div class="lever-track">
+                <span class="lever-stop">VENT</span>
+                <input type="range" min="0" max="4" value="2" />
+                <span class="lever-stop">FLOOD</span>
+              </div>
+              <div class="lever-readout">Trim shift: <span class="lever-value">0</span></div>
+            </div>
+            <div class="ballast-lever" data-lever="stern">
+              <div class="lever-title">Stern Pumps</div>
+              <div class="lever-track">
+                <span class="lever-stop">VENT</span>
+                <input type="range" min="0" max="4" value="2" />
+                <span class="lever-stop">FLOOD</span>
+              </div>
+              <div class="lever-readout">Trim shift: <span class="lever-value">0</span></div>
+            </div>
+            <div class="ballast-lever" data-lever="port">
+              <div class="lever-title">Port Trim</div>
+              <div class="lever-track">
+                <span class="lever-stop">VENT</span>
+                <input type="range" min="0" max="4" value="2" />
+                <span class="lever-stop">FLOOD</span>
+              </div>
+              <div class="lever-readout">Trim shift: <span class="lever-value">0</span></div>
+            </div>
+            <div class="ballast-lever" data-lever="starboard">
+              <div class="lever-title">Starboard Trim</div>
+              <div class="lever-track">
+                <span class="lever-stop">VENT</span>
+                <input type="range" min="0" max="4" value="2" />
+                <span class="lever-stop">FLOOD</span>
+              </div>
+              <div class="lever-readout">Trim shift: <span class="lever-value">0</span></div>
+            </div>
+          </div>
+          <div class="ballast-actions">
+            <button id="ballast-polarity" class="toggle-button">Polarity: Flood Tanks</button>
+            <button id="ballast-confirm" class="confirm-button">Confirm Adjustment</button>
+            <div class="ballast-moves">Moves remaining: <span id="ballast-moves">0</span></div>
+            <div class="ballast-digital" id="ballast-digital">Stability score: --</div>
+          </div>
+        </div>
+        <div class="ballast-gauges">
+          <div class="gauge tilt-gauge">
+            <div class="gauge-face">
+              <div class="needle"></div>
+              <div class="gauge-center"></div>
+            </div>
+            <div class="gauge-label">Trim Gauge</div>
+            <div class="gauge-readout" id="ballast-tilt-readout">--</div>
+          </div>
+          <div class="gauge depth-gauge">
+            <div class="gauge-face">
+              <div class="needle"></div>
+              <div class="gauge-center"></div>
+            </div>
+            <div class="gauge-label">Depth Gauge</div>
+            <div class="gauge-readout" id="ballast-depth-readout">--</div>
+          </div>
+        </div>
+      </div>
+      <div class="ballast-status" id="ballast-status">Ballast array warming up…</div>
+      <div class="ballast-outcome" id="ballast-outcome"></div>
+      <div class="ballast-reset">
+        <button id="ballast-reset">Reset Ballast System</button>
+      </div>
+    </div>
+  </section>
+
+  <section id="sonar">
+    <div class="content-box placeholder">
+      <h2>📡 Sonar Shapes</h2>
+      <p>Sonar arrays are aligning. Puzzle upload pending.</p>
+    </div>
+  </section>
+
+  <section id="navigation">
+    <div class="content-box placeholder">
+      <h2>🗺️ Nav Riddle</h2>
+      <p>The captain's logbook is sealed tight. Await further instructions.</p>
+    </div>
+  </section>
+
   <script src="control-unlock.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -69,6 +69,12 @@ section.active {
   box-shadow: 0 0 10px #0077b6;
 }
 
+.placeholder {
+  text-align: center;
+  font-style: italic;
+  color: rgba(202, 240, 248, 0.7);
+}
+
 .peg {
   width: 2rem;
   height: 2rem;
@@ -148,4 +154,397 @@ section.active {
   margin-top: 0.5rem;
   color: #90e0ef;
   font-size: 0.8rem;
+}
+
+.ballast-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  background: linear-gradient(145deg, rgba(1, 22, 39, 0.95), rgba(3, 4, 94, 0.65));
+  border: 1px solid rgba(72, 202, 228, 0.25);
+  box-shadow: 0 0 25px rgba(0, 119, 182, 0.4);
+  overflow: hidden;
+  position: relative;
+}
+
+.ballast-panel::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 15% 15%, rgba(255, 209, 102, 0.08), transparent 55%);
+  pointer-events: none;
+}
+
+.ballast-panel > div:first-child {
+  position: relative;
+  z-index: 1;
+}
+
+.ballast-body {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  justify-content: space-between;
+  position: relative;
+  z-index: 1;
+}
+
+.ballast-controls {
+  flex: 1 1 360px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.lever-bank {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: space-between;
+}
+
+.ballast-lever {
+  flex: 1 1 160px;
+  min-width: 150px;
+  background: rgba(1, 15, 32, 0.75);
+  border: 1px solid rgba(72, 202, 228, 0.25);
+  border-radius: 0.6rem;
+  padding: 0.75rem;
+  box-shadow: inset 0 0 12px rgba(0, 0, 0, 0.45);
+  position: relative;
+}
+
+.lever-title {
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  margin-bottom: 0.5rem;
+  color: #ffd166;
+  text-transform: uppercase;
+}
+
+.lever-track {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.lever-stop {
+  font-size: 0.7rem;
+  letter-spacing: 0.16em;
+  color: rgba(202, 240, 248, 0.55);
+}
+
+.ballast-lever input[type='range'] {
+  flex: 1;
+  -webkit-appearance: none;
+  appearance: none;
+  height: 6px;
+  background: linear-gradient(90deg, rgba(148, 187, 233, 0.15), rgba(255, 209, 102, 0.25));
+  border-radius: 3px;
+  border: 1px solid rgba(72, 202, 228, 0.25);
+  box-shadow: inset 0 0 4px rgba(0, 0, 0, 0.45);
+  position: relative;
+}
+
+.ballast-lever input[type='range']::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 35%, #ffe066, #caa56a 60%, #8d5524 100%);
+  border: 2px solid #5c3d2e;
+  box-shadow: 0 0 8px rgba(255, 209, 102, 0.5);
+  cursor: pointer;
+}
+
+.ballast-lever input[type='range']::-moz-range-thumb {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 35%, #ffe066, #caa56a 60%, #8d5524 100%);
+  border: 2px solid #5c3d2e;
+  box-shadow: 0 0 8px rgba(255, 209, 102, 0.5);
+  cursor: pointer;
+}
+
+.ballast-lever input[type='range']::-webkit-slider-runnable-track {
+  height: 6px;
+  background: transparent;
+}
+
+.ballast-lever input[type='range']::-moz-range-track {
+  height: 6px;
+  background: transparent;
+}
+
+.lever-readout {
+  margin-top: 0.5rem;
+  font-size: 0.85rem;
+  text-align: center;
+  color: #caf0f8;
+}
+
+.lever-readout .lever-value {
+  color: #ffd166;
+  font-weight: 700;
+  margin-left: 0.25rem;
+}
+
+.ballast-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.ballast-actions button,
+.ballast-reset button {
+  background: #184e77;
+  color: #fff;
+  border: 1px solid #48cae4;
+  border-radius: 0.5rem;
+  padding: 0.55rem 1rem;
+  font-size: 0.9rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+.ballast-actions button:hover,
+.ballast-reset button:hover {
+  background: #1a759f;
+  box-shadow: 0 0 12px rgba(72, 202, 228, 0.35);
+  transform: translateY(-1px);
+}
+
+.ballast-actions button:disabled,
+.ballast-reset button:disabled {
+  background: rgba(42, 71, 94, 0.6);
+  border-color: rgba(64, 64, 64, 0.6);
+  color: rgba(180, 180, 180, 0.5);
+  box-shadow: none;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.toggle-button {
+  background: #2b2d42;
+  border-color: #ffd166;
+  color: #ffd166;
+}
+
+.toggle-button.venting {
+  background: #3a506b;
+  border-color: #90e0ef;
+  color: #90e0ef;
+}
+
+.ballast-moves {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #adb5bd;
+}
+
+.ballast-moves span {
+  color: #ffd166;
+  font-weight: 700;
+}
+
+.ballast-digital {
+  background: rgba(1, 22, 39, 0.6);
+  border: 1px solid rgba(72, 202, 228, 0.25);
+  border-radius: 0.4rem;
+  padding: 0.5rem;
+  text-align: center;
+  font-family: 'Courier New', Courier, monospace;
+  letter-spacing: 0.1em;
+  color: #ade8f4;
+  transition: box-shadow 0.3s ease, border-color 0.3s ease, color 0.3s ease;
+}
+
+.ballast-digital[data-level='stable'] {
+  color: #b7efc5;
+  border-color: rgba(72, 201, 176, 0.5);
+  box-shadow: 0 0 16px rgba(72, 201, 176, 0.45);
+}
+
+.ballast-digital[data-level='caution'] {
+  color: #ffe066;
+  border-color: rgba(255, 193, 7, 0.4);
+  box-shadow: 0 0 16px rgba(255, 193, 7, 0.35);
+}
+
+.ballast-digital[data-level='danger'] {
+  color: #ff8585;
+  border-color: rgba(255, 82, 82, 0.35);
+  box-shadow: 0 0 16px rgba(255, 82, 82, 0.35);
+}
+
+.ballast-gauges {
+  flex: 1 1 260px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  z-index: 1;
+}
+
+.gauge {
+  width: 180px;
+  padding: 1rem;
+  text-align: center;
+  background: rgba(1, 20, 40, 0.85);
+  border: 1px solid rgba(72, 202, 228, 0.25);
+  border-radius: 1rem;
+  box-shadow: inset 0 0 12px rgba(0, 0, 0, 0.5);
+}
+
+.gauge-face {
+  position: relative;
+  width: 120px;
+  height: 120px;
+  margin: 0 auto 1rem;
+  border-radius: 50%;
+  background: radial-gradient(circle at 50% 50%, rgba(220, 220, 220, 0.12), rgba(1, 31, 57, 0.95));
+  border: 3px solid rgba(168, 218, 220, 0.4);
+  overflow: hidden;
+}
+
+.gauge-face::after {
+  content: '';
+  position: absolute;
+  inset: 8px;
+  border-radius: 50%;
+  border: 1px dashed rgba(168, 218, 220, 0.35);
+}
+
+.needle {
+  position: absolute;
+  bottom: 50%;
+  left: 50%;
+  width: 4px;
+  height: 56px;
+  background: linear-gradient(180deg, #ffd166, #ff7b00);
+  transform-origin: 50% 100%;
+  transform: rotate(0deg);
+  transition: transform 0.4s ease;
+  box-shadow: 0 0 10px rgba(255, 209, 102, 0.5);
+}
+
+.gauge-center {
+  position: absolute;
+  bottom: 50%;
+  left: 50%;
+  width: 16px;
+  height: 16px;
+  background: #184e77;
+  border-radius: 50%;
+  transform: translate(-50%, 50%);
+  border: 2px solid #90e0ef;
+  box-shadow: 0 0 6px rgba(144, 224, 239, 0.5);
+}
+
+.gauge-label {
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: #ade8f4;
+}
+
+.gauge-readout {
+  margin-top: 0.4rem;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  color: #ffd166;
+  font-family: 'Courier New', Courier, monospace;
+}
+
+.ballast-status {
+  position: relative;
+  z-index: 1;
+  padding: 0.85rem 1rem;
+  border-radius: 0.6rem;
+  border: 1px solid rgba(255, 99, 132, 0.35);
+  background: rgba(153, 27, 27, 0.25);
+  color: #ffc9c9;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  min-height: 3.5rem;
+  display: flex;
+  align-items: center;
+}
+
+.ballast-status.caution {
+  border-color: rgba(255, 193, 7, 0.4);
+  background: rgba(255, 193, 7, 0.18);
+  color: #ffec99;
+}
+
+.ballast-status.stable {
+  border-color: rgba(72, 201, 176, 0.45);
+  background: rgba(72, 201, 176, 0.2);
+  color: #d8f3dc;
+}
+
+.ballast-status.danger {
+  border-color: rgba(255, 99, 132, 0.35);
+  background: rgba(153, 27, 27, 0.25);
+  color: #ffc9c9;
+}
+
+.ballast-outcome {
+  position: relative;
+  z-index: 1;
+  min-height: 1.6rem;
+  text-align: center;
+  font-size: 1.2rem;
+  letter-spacing: 0.12em;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.ballast-outcome.success {
+  color: #9ef01a;
+  text-shadow: 0 0 14px rgba(158, 240, 26, 0.6);
+}
+
+.ballast-outcome.failure {
+  color: #ff6b6b;
+  text-shadow: 0 0 14px rgba(255, 86, 110, 0.6);
+}
+
+.ballast-reset {
+  position: relative;
+  z-index: 1;
+  text-align: right;
+}
+
+.ballast-panel.ballast-stable {
+  border-color: rgba(72, 201, 176, 0.45);
+  box-shadow: 0 0 28px rgba(72, 201, 176, 0.35);
+}
+
+.ballast-panel.ballast-caution {
+  border-color: rgba(255, 193, 7, 0.35);
+  box-shadow: 0 0 28px rgba(255, 193, 7, 0.28);
+}
+
+.ballast-panel.ballast-danger {
+  border-color: rgba(239, 71, 111, 0.35);
+  box-shadow: 0 0 28px rgba(239, 71, 111, 0.35);
+}
+
+@media (max-width: 960px) {
+  .gauge {
+    width: 160px;
+  }
+
+  .gauge-face {
+    width: 110px;
+    height: 110px;
+  }
 }


### PR DESCRIPTION
## Summary
- implement the Ballast Balance puzzle section with levers, gauges, polarity toggle, and feedback panels
- add styling for ballast controls, gauges, and placeholder sections for other puzzles
- extend the JavaScript controller to handle tab navigation, ballast puzzle logic, resets, and developer tooling output

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d07ed66454832595a168872413084b