### PR TITLE
Add interactive porthole spot-the-difference puzzle

### DIFF
--- a/control-unlock.js
+++ b/control-unlock.js
@@ -209,6 +209,39 @@
     resetPuzzle();
   }
 
+  function enhancePortholeIntegration() {
+    const originalReset = window.resetGame;
+    const originalReveal = window.revealSolution;
+
+    document.addEventListener('DOMContentLoaded', () => {
+      if (typeof window.initializePortholePuzzle === 'function') {
+        window.initializePortholePuzzle();
+      }
+    });
+
+    window.resetGame = function (...args) {
+      if (typeof originalReset === 'function') {
+        originalReset.apply(this, args);
+      }
+      if (typeof window.resetPortholePuzzle === 'function') {
+        window.resetPortholePuzzle();
+      }
+    };
+
+    window.revealSolution = function (...args) {
+      const result =
+        typeof originalReveal === 'function' ? originalReveal.apply(this, args) : undefined;
+
+      if (typeof window.revealPortholeSolution === 'function') {
+        window.revealPortholeSolution();
+      }
+
+      return result;
+    };
+  }
+
+  enhancePortholeIntegration();
+
   app.registerPuzzle('control-unlock', {
     init: initPuzzle,
     reset: resetPuzzle,

--- a/index.html
+++ b/index.html
@@ -36,9 +36,64 @@
   </section>
 
   <section id="spot-diff">
-    <div class="content-box placeholder">
-      <h2>🔍 Porthole Puzzle</h2>
-      <p>The porthole display is still calibrating. Check back soon for this challenge.</p>
+    <div class="content-box">
+      <div class="porthole-puzzle">
+        <div class="porthole-intro">
+          <h2>🔍 Porthole Puzzle</h2>
+          <p>
+            Two observation windows show the sea outside the submarine. Study the port and starboard scenes,
+            then tap every mismatch to flag it for the crew.
+          </p>
+        </div>
+        <div class="porthole-scenes">
+          <div class="porthole-scene" data-scene="port">
+            <div class="porthole-frame">
+              <div class="porthole-glass" role="img" aria-label="Port observation porthole">
+                <div class="scene-detail hull"></div>
+                <div class="scene-detail tower"></div>
+                <div class="scene-detail viewport viewport-a"></div>
+                <div class="scene-detail viewport viewport-b"></div>
+                <div class="scene-detail viewport viewport-c"></div>
+                <div class="scene-detail buoy"></div>
+                <div class="scene-detail kelp kelp-port"></div>
+                <div class="scene-detail kelp kelp-starboard"></div>
+                <div class="scene-detail jellyfish"></div>
+                <div class="scene-detail sonar"></div>
+                <div class="scene-detail bubbles cluster-one"></div>
+                <div class="scene-detail bubbles cluster-two"></div>
+              </div>
+            </div>
+            <div class="porthole-label">Port Observation</div>
+          </div>
+          <div class="porthole-scene" data-scene="starboard">
+            <div class="porthole-frame">
+              <div class="porthole-glass" role="img" aria-label="Starboard observation porthole">
+                <div class="scene-detail hull"></div>
+                <div class="scene-detail tower"></div>
+                <div class="scene-detail viewport viewport-a"></div>
+                <div class="scene-detail viewport viewport-b"></div>
+                <div class="scene-detail viewport viewport-c"></div>
+                <div class="scene-detail buoy"></div>
+                <div class="scene-detail kelp kelp-port"></div>
+                <div class="scene-detail kelp kelp-starboard"></div>
+                <div class="scene-detail jellyfish"></div>
+                <div class="scene-detail sonar"></div>
+                <div class="scene-detail bubbles cluster-one"></div>
+                <div class="scene-detail bubbles cluster-two"></div>
+              </div>
+            </div>
+            <div class="porthole-label">Starboard Observation</div>
+          </div>
+        </div>
+        <div class="porthole-progress" role="status" aria-live="polite">
+          Found <span id="porthole-found-count">0</span> of <span id="porthole-total-count">0</span> differences ·
+          <span class="porthole-progress-message" id="porthole-progress-message">Mark each mismatch to light the signal.</span>
+        </div>
+        <div class="porthole-success" id="porthole-success" aria-live="assertive">
+          <p>All differences spotted! Keyword:</p>
+          <p class="porthole-keyword" id="porthole-keyword"></p>
+        </div>
+      </div>
     </div>
   </section>
 
@@ -137,6 +192,7 @@
   </section>
 
   <script src="utils.js"></script>
+  <script src="porthole.js"></script>
   <script src="control-unlock.js"></script>
   <script src="ballast.js"></script>
   <script src="spot-diff.js"></script>

--- a/porthole.js
+++ b/porthole.js
@@ -1,0 +1,272 @@
+(function (global) {
+  const KEYWORD = 'PERISCOPE';
+
+  const differences = [
+    {
+      id: 'buoy-flag',
+      label: 'Signal buoy flag',
+      positions: {
+        port: { x: 28, y: 22 },
+        starboard: { x: 28, y: 22 },
+      },
+      found: false,
+    },
+    {
+      id: 'jellyfish-glow',
+      label: 'Glowing jellyfish',
+      positions: {
+        port: { x: 76, y: 36 },
+        starboard: { x: 76, y: 36 },
+      },
+      found: false,
+    },
+    {
+      id: 'sonar-ping',
+      label: 'Sonar pulse ring',
+      positions: {
+        port: { x: 50, y: 38 },
+        starboard: { x: 50, y: 38 },
+      },
+      found: false,
+    },
+    {
+      id: 'kelp-height',
+      label: 'Starboard kelp height',
+      positions: {
+        port: { x: 82, y: 70 },
+        starboard: { x: 82, y: 70 },
+      },
+      found: false,
+    },
+    {
+      id: 'vent-bubbles',
+      label: 'Vent bubble cluster',
+      positions: {
+        port: { x: 26, y: 68 },
+        starboard: { x: 26, y: 68 },
+      },
+      found: false,
+    },
+    {
+      id: 'extra-viewport',
+      label: 'Extra hull viewport',
+      positions: {
+        port: { x: 68, y: 60 },
+        starboard: { x: 68, y: 60 },
+      },
+      found: false,
+    },
+  ];
+
+  const differenceMap = new Map(differences.map(diff => [diff.id, diff]));
+
+  const state = {
+    container: null,
+    scenes: new Map(),
+    markers: new Map(),
+    progressCount: null,
+    totalCount: null,
+    progressMessage: null,
+    successBanner: null,
+    keywordNode: null,
+    initialised: false,
+  };
+
+  const progressMessages = {
+    start: 'Mark each mismatch to light the signal.',
+    mid: 'Keep scanning the portholes for anomalies.',
+    complete: 'All differences logged. Signal ready to transmit.',
+  };
+
+  function ensureElements() {
+    const container = document.querySelector('.porthole-puzzle');
+    if (!container) {
+      return false;
+    }
+
+    state.container = container;
+    state.progressCount = container.querySelector('#porthole-found-count');
+    state.totalCount = container.querySelector('#porthole-total-count');
+    state.progressMessage = container.querySelector('#porthole-progress-message');
+    state.successBanner = container.querySelector('#porthole-success');
+    state.keywordNode = container.querySelector('#porthole-keyword');
+
+    const portScene = container.querySelector('[data-scene="port"] .porthole-glass');
+    const starboardScene = container.querySelector('[data-scene="starboard"] .porthole-glass');
+
+    state.scenes.clear();
+    state.scenes.set('port', portScene);
+    state.scenes.set('starboard', starboardScene);
+
+    return Boolean(portScene && starboardScene);
+  }
+
+  function buildMarkers() {
+    state.markers.clear();
+
+    differences.forEach(diff => {
+      const markerSet = [];
+
+      Object.entries(diff.positions).forEach(([sceneKey, coords]) => {
+        const scene = state.scenes.get(sceneKey);
+        if (!scene) {
+          return;
+        }
+
+        const marker = document.createElement('button');
+        marker.type = 'button';
+        marker.className = 'difference-marker';
+        marker.dataset.differenceId = diff.id;
+        marker.dataset.scene = sceneKey;
+        marker.style.left = `${coords.x}%`;
+        marker.style.top = `${coords.y}%`;
+        marker.setAttribute('aria-label', `${diff.label}. Tap to toggle found state.`);
+        marker.setAttribute('aria-pressed', 'false');
+        marker.addEventListener('click', handleMarkerClick);
+        scene.appendChild(marker);
+        markerSet.push(marker);
+      });
+
+      state.markers.set(diff.id, markerSet);
+    });
+  }
+
+  function setMarkerState(diffId, found) {
+    const markerSet = state.markers.get(diffId);
+    if (!markerSet) {
+      return;
+    }
+
+    markerSet.forEach(marker => {
+      marker.classList.toggle('found', found);
+      marker.setAttribute('aria-pressed', found ? 'true' : 'false');
+    });
+  }
+
+  function countFound() {
+    return differences.reduce((total, diff) => (diff.found ? total + 1 : total), 0);
+  }
+
+  function updateProgress() {
+    const total = differences.length;
+    const foundCount = countFound();
+
+    if (state.progressCount) {
+      state.progressCount.textContent = String(foundCount);
+    }
+
+    if (state.totalCount) {
+      state.totalCount.textContent = String(total);
+    }
+
+    if (state.progressMessage) {
+      let message = progressMessages.start;
+      if (foundCount === total && total > 0) {
+        message = progressMessages.complete;
+      } else if (foundCount > 0) {
+        message = progressMessages.mid;
+      }
+      state.progressMessage.textContent = message;
+    }
+
+    if (foundCount === total && total > 0) {
+      showSuccess();
+    } else {
+      hideSuccess();
+    }
+  }
+
+  function showSuccess() {
+    if (state.successBanner) {
+      state.successBanner.classList.add('visible');
+    }
+    if (state.keywordNode) {
+      state.keywordNode.textContent = KEYWORD;
+    }
+    if (global.SubControls && typeof global.SubControls.setKeywordBanner === 'function') {
+      global.SubControls.setKeywordBanner(`🔓 UNLOCKED: ${KEYWORD}`, 'spot-diff');
+    }
+  }
+
+  function hideSuccess() {
+    if (state.successBanner) {
+      state.successBanner.classList.remove('visible');
+    }
+    if (state.keywordNode && !countFound()) {
+      state.keywordNode.textContent = '';
+    }
+    if (global.SubControls && typeof global.SubControls.clearKeywordBanner === 'function') {
+      global.SubControls.clearKeywordBanner('spot-diff');
+    }
+  }
+
+  function handleMarkerClick(event) {
+    const target = event.currentTarget;
+    if (!target) {
+      return;
+    }
+
+    const diffId = target.dataset.differenceId;
+    const diff = diffId ? differenceMap.get(diffId) : null;
+    if (!diff) {
+      return;
+    }
+
+    diff.found = !diff.found;
+    setMarkerState(diff.id, diff.found);
+    updateProgress();
+  }
+
+  function resetState() {
+    differences.forEach(diff => {
+      diff.found = false;
+      setMarkerState(diff.id, false);
+    });
+    hideSuccess();
+    updateProgress();
+  }
+
+  function preparePuzzle() {
+    if (!ensureElements()) {
+      return false;
+    }
+
+    if (!state.initialised) {
+      buildMarkers();
+      state.initialised = true;
+    }
+
+    return true;
+  }
+
+  function initialisePuzzle() {
+    if (!preparePuzzle()) {
+      return;
+    }
+    resetState();
+  }
+
+  function resetPuzzle() {
+    if (!preparePuzzle()) {
+      return;
+    }
+    resetState();
+  }
+
+  function revealPuzzle() {
+    if (!preparePuzzle()) {
+      return;
+    }
+
+    differences.forEach(diff => {
+      diff.found = true;
+      setMarkerState(diff.id, true);
+    });
+
+    updateProgress();
+  }
+
+  global.initializePortholePuzzle = initialisePuzzle;
+  global.resetPortholePuzzle = resetPuzzle;
+  global.revealPortholeSolution = revealPuzzle;
+})(window);

--- a/spot-diff.js
+++ b/spot-diff.js
@@ -3,16 +3,26 @@
     return;
   }
 
+  const KEYWORD = 'PERISCOPE';
+
+  function callIfAvailable(handlerName) {
+    const handler = window[handlerName];
+    if (typeof handler === 'function') {
+      handler();
+    }
+  }
+
   function initPuzzle() {
-    // Placeholder for future spot-the-difference setup.
+    callIfAvailable('initializePortholePuzzle');
   }
 
   function resetPuzzle() {
-    // No dynamic state yet; reserved for future implementation.
+    callIfAvailable('resetPortholePuzzle');
   }
 
   function revealHint() {
-    return '🔍 Porthole Puzzle: Calibration pending.';
+    callIfAvailable('revealPortholeSolution');
+    return `🔍 Porthole Puzzle Keyword: ${KEYWORD}`;
   }
 
   app.registerPuzzle('spot-diff', {

--- a/style.css
+++ b/style.css
@@ -75,6 +75,432 @@ section.active {
   color: rgba(202, 240, 248, 0.7);
 }
 
+.porthole-puzzle {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.porthole-intro h2 {
+  margin-bottom: 0.5rem;
+}
+
+.porthole-intro p {
+  margin: 0;
+  color: rgba(202, 240, 248, 0.85);
+}
+
+.porthole-scenes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  justify-content: center;
+}
+
+.porthole-scene {
+  flex: 1 1 240px;
+  max-width: 320px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.porthole-frame {
+  width: 100%;
+  padding: 0.85rem;
+  border-radius: 50%;
+  background: linear-gradient(145deg, rgba(0, 36, 82, 0.9), rgba(0, 119, 182, 0.45));
+  box-shadow: 0 0 18px rgba(0, 119, 182, 0.45);
+  position: relative;
+}
+
+.porthole-frame::before {
+  content: '';
+  position: absolute;
+  inset: 0.5rem;
+  border-radius: 50%;
+  border: 2px solid rgba(72, 202, 228, 0.25);
+  pointer-events: none;
+}
+
+.porthole-glass {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  border-radius: 50%;
+  overflow: hidden;
+  border: 4px solid rgba(144, 224, 239, 0.45);
+  background: radial-gradient(circle at 25% 20%, rgba(144, 224, 239, 0.55), rgba(3, 4, 94, 0.9));
+  box-shadow: inset 0 0 30px rgba(1, 22, 39, 0.85), 0 0 18px rgba(72, 202, 228, 0.3);
+}
+
+.porthole-glass::after {
+  content: '';
+  position: absolute;
+  inset: 12%;
+  border-radius: 50%;
+  background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.12), transparent 65%);
+  pointer-events: none;
+}
+
+.porthole-label {
+  text-transform: uppercase;
+  letter-spacing: 0.08rem;
+  font-size: 0.95rem;
+  color: #90e0ef;
+}
+
+.porthole-glass .scene-detail {
+  position: absolute;
+}
+
+.porthole-glass .scene-detail.hull {
+  width: 76%;
+  height: 40%;
+  left: 50%;
+  bottom: 12%;
+  transform: translateX(-50%);
+  background: linear-gradient(180deg, rgba(3, 4, 94, 0.75), rgba(1, 22, 39, 0.95));
+  border-radius: 45% 45% 50% 50%;
+  border: 2px solid rgba(0, 36, 82, 0.85);
+  box-shadow: 0 0 18px rgba(0, 36, 82, 0.6);
+}
+
+.porthole-glass .scene-detail.tower {
+  width: 22%;
+  height: 26%;
+  left: 50%;
+  bottom: 48%;
+  transform: translateX(-50%);
+  background: linear-gradient(180deg, rgba(144, 224, 239, 0.9), rgba(0, 96, 150, 0.6));
+  border-radius: 45% 45% 8% 8%;
+  box-shadow: 0 0 12px rgba(72, 202, 228, 0.55);
+}
+
+.porthole-glass .scene-detail.tower::after {
+  content: '';
+  position: absolute;
+  width: 24%;
+  height: 65%;
+  right: 14%;
+  top: -55%;
+  background: rgba(202, 240, 248, 0.8);
+  border-radius: 50% 50% 35% 35%;
+  box-shadow: 0 0 10px rgba(173, 232, 244, 0.7);
+}
+
+.porthole-glass .scene-detail.viewport {
+  width: 12%;
+  height: 12%;
+  bottom: 22%;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 35%, rgba(202, 240, 248, 0.95), rgba(0, 119, 182, 0.55));
+  border: 2px solid rgba(173, 232, 244, 0.7);
+  box-shadow: 0 0 10px rgba(72, 202, 228, 0.5);
+}
+
+.porthole-glass .scene-detail.viewport.viewport-a {
+  left: 32%;
+}
+
+.porthole-glass .scene-detail.viewport.viewport-b {
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.porthole-glass .scene-detail.viewport.viewport-c {
+  left: 68%;
+}
+
+[data-scene='starboard'] .scene-detail.viewport.viewport-c {
+  display: none;
+}
+
+.porthole-glass .scene-detail.buoy {
+  width: 18%;
+  height: 18%;
+  top: 24%;
+  left: 28%;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 30%, rgba(202, 240, 248, 0.9), rgba(0, 119, 182, 0.6));
+  box-shadow: 0 0 12px rgba(144, 224, 239, 0.6);
+}
+
+.porthole-glass .scene-detail.buoy::before {
+  content: '';
+  position: absolute;
+  width: 3px;
+  height: 180%;
+  top: -110%;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(173, 232, 244, 0.85);
+  border-radius: 2px;
+}
+
+.porthole-glass .scene-detail.buoy::after {
+  content: '';
+  position: absolute;
+  left: calc(50% + 2px);
+  top: -122%;
+  border-style: solid;
+  border-width: 8px 0 8px 13px;
+  border-color: transparent transparent transparent rgba(72, 202, 228, 0.9);
+}
+
+[data-scene='starboard'] .scene-detail.buoy::after {
+  border-left-color: transparent;
+}
+
+.porthole-glass .scene-detail.kelp {
+  width: 10%;
+  bottom: 8%;
+  background: linear-gradient(180deg, rgba(72, 202, 228, 0.9), rgba(0, 36, 82, 0.35));
+  border-radius: 50% 50% 0 0;
+  box-shadow: 0 0 14px rgba(72, 202, 228, 0.35);
+}
+
+.porthole-glass .scene-detail.kelp::after {
+  content: '';
+  position: absolute;
+  width: 140%;
+  height: 55%;
+  left: 50%;
+  bottom: 25%;
+  transform: translateX(-50%) rotate(12deg);
+  border-radius: 45% 45% 20% 20%;
+  background: rgba(144, 224, 239, 0.35);
+}
+
+.porthole-glass .scene-detail.kelp.kelp-port {
+  left: 14%;
+  height: 48%;
+}
+
+.porthole-glass .scene-detail.kelp.kelp-starboard {
+  right: 14%;
+  height: 55%;
+}
+
+[data-scene='starboard'] .scene-detail.kelp.kelp-starboard {
+  height: 34%;
+}
+
+.porthole-glass .scene-detail.jellyfish {
+  width: 24%;
+  height: 18%;
+  top: 34%;
+  right: 16%;
+  border-radius: 50% 50% 60% 60%;
+  background: radial-gradient(circle at 50% 35%, rgba(173, 232, 244, 0.85), rgba(0, 119, 182, 0.25));
+  box-shadow: 0 0 14px rgba(144, 224, 239, 0.55);
+  opacity: 0.95;
+}
+
+.porthole-glass .scene-detail.jellyfish::after {
+  content: '';
+  position: absolute;
+  bottom: -45%;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 75%;
+  height: 65%;
+  border-radius: 50% 50% 70% 70%;
+  background: radial-gradient(circle, rgba(173, 232, 244, 0.5), transparent 70%);
+  filter: blur(2px);
+}
+
+[data-scene='port'] .scene-detail.jellyfish {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.porthole-glass .scene-detail.sonar {
+  width: 58%;
+  height: 58%;
+  top: 18%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-radius: 50%;
+  border: 2px solid rgba(144, 224, 239, 0.35);
+  box-shadow: 0 0 18px rgba(72, 202, 228, 0.35);
+  opacity: 0.35;
+}
+
+.porthole-glass .scene-detail.sonar::after {
+  content: '';
+  position: absolute;
+  inset: 14%;
+  border-radius: 50%;
+  border: 2px solid rgba(72, 202, 228, 0.25);
+  animation: sonarPulse 5.5s linear infinite;
+}
+
+[data-scene='starboard'] .scene-detail.sonar {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.porthole-glass .scene-detail.bubbles {
+  width: 6%;
+  height: 6%;
+  border-radius: 50%;
+  background: rgba(173, 232, 244, 0.85);
+  box-shadow: 0 0 12px rgba(144, 224, 239, 0.45);
+  opacity: 0.85;
+}
+
+.porthole-glass .scene-detail.bubbles::before,
+.porthole-glass .scene-detail.bubbles::after {
+  content: '';
+  position: absolute;
+  border-radius: 50%;
+  background: rgba(173, 232, 244, 0.65);
+}
+
+.porthole-glass .scene-detail.bubbles::before {
+  width: 75%;
+  height: 75%;
+  left: -55%;
+  top: -25%;
+}
+
+.porthole-glass .scene-detail.bubbles::after {
+  width: 50%;
+  height: 50%;
+  right: -45%;
+  bottom: 10%;
+  opacity: 0.85;
+}
+
+.porthole-glass .scene-detail.bubbles.cluster-one {
+  left: 22%;
+  bottom: 38%;
+}
+
+.porthole-glass .scene-detail.bubbles.cluster-two {
+  left: 30%;
+  bottom: 24%;
+}
+
+[data-scene='starboard'] .scene-detail.bubbles.cluster-two {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.difference-marker {
+  position: absolute;
+  width: 2.75rem;
+  height: 2.75rem;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  border: 2px dashed rgba(173, 232, 244, 0.7);
+  background: rgba(0, 119, 182, 0.18);
+  box-shadow: 0 0 10px rgba(72, 202, 228, 0.3);
+  cursor: pointer;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.55;
+  transition: opacity 0.25s ease, background 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease;
+  color: transparent;
+}
+
+.difference-marker:hover,
+.difference-marker:focus {
+  opacity: 1;
+  border-style: solid;
+  border-color: rgba(144, 224, 239, 0.95);
+  background: rgba(0, 119, 182, 0.35);
+  box-shadow: 0 0 16px rgba(72, 202, 228, 0.65);
+  outline: none;
+}
+
+.difference-marker.found {
+  opacity: 1;
+  border-style: solid;
+  border-color: rgba(72, 202, 228, 0.95);
+  background: rgba(72, 202, 228, 0.9);
+  box-shadow: 0 0 18px rgba(144, 224, 239, 0.8);
+  color: #03045e;
+}
+
+.porthole-progress {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  background: rgba(0, 119, 182, 0.18);
+  border: 1px solid rgba(144, 224, 239, 0.35);
+  color: #ade8f4;
+  font-weight: 500;
+}
+
+.porthole-progress span {
+  font-weight: 600;
+  color: #90e0ef;
+}
+
+.porthole-progress-message {
+  color: rgba(202, 240, 248, 0.85);
+  font-size: 0.95rem;
+}
+
+.porthole-success {
+  display: none;
+  padding: 1rem;
+  border-radius: 0.75rem;
+  background: linear-gradient(135deg, rgba(72, 202, 228, 0.12), rgba(0, 119, 182, 0.25));
+  border: 1px solid rgba(72, 202, 228, 0.55);
+  text-align: center;
+  color: #caf0f8;
+  box-shadow: 0 0 20px rgba(0, 180, 216, 0.35);
+}
+
+.porthole-success.visible {
+  display: block;
+}
+
+.porthole-keyword {
+  margin: 0.35rem 0 0;
+  font-size: 1.8rem;
+  font-weight: 700;
+  letter-spacing: 0.35rem;
+  color: #48cae4;
+  text-transform: uppercase;
+  text-shadow: 0 0 18px rgba(72, 202, 228, 0.7);
+}
+
+@keyframes sonarPulse {
+  0% {
+    transform: scale(0.85);
+    opacity: 0.4;
+  }
+  70% {
+    opacity: 0.9;
+  }
+  100% {
+    transform: scale(1.25);
+    opacity: 0;
+  }
+}
+
+@media (max-width: 720px) {
+  .porthole-scenes {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .porthole-frame {
+    max-width: 240px;
+  }
+}
+
 .peg {
   width: 2rem;
   height: 2rem;


### PR DESCRIPTION
## Summary
- replace the placeholder porthole section with an interactive puzzle layout, counter, and success banner
- add nautical-themed styles for the new porthole scenes, hotspots, and status messaging
- implement the spot-the-difference logic in a dedicated module and hook its initialise/reset/reveal helpers into the existing controls

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68d088ab41e0832580f9e280b617bd96