### PR TITLE
Add interactive sonar puzzle

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,9 +123,21 @@
   </section>
 
   <section id="sonar">
-    <div class="content-box placeholder">
-      <h2>📡 Sonar Shapes</h2>
-      <p>Sonar arrays are aligning. Puzzle upload pending.</p>
+    <div class="content-box">
+      <div class="sonar-console">
+        <div>
+          <h2>📡 Sonar Shapes</h2>
+          <p class="sonar-description">
+            Cycle the pings to trace the contact silhouette. The row and column readouts show how many sonar pips should glow in
+            each line—overcharge a lane and the console will refuse the input.
+          </p>
+        </div>
+        <div class="sonar-grid" id="sonar-grid" role="grid" aria-label="Sonar targeting grid"></div>
+        <p class="sonar-clue" id="sonar-clue"></p>
+        <div class="sonar-success" id="sonar-success" hidden>
+          <strong>Keyword detected:</strong> <span id="sonar-keyword">TORPEDO</span>
+        </div>
+      </div>
     </div>
   </section>
 
@@ -136,11 +148,11 @@
     </div>
   </section>
 
+  <script src="sonar.js"></script>
   <script src="utils.js"></script>
   <script src="control-unlock.js"></script>
   <script src="ballast.js"></script>
   <script src="spot-diff.js"></script>
-  <script src="sonar.js"></script>
   <script src="navigation.js"></script>
 </body>
 </html>

--- a/sonar.js
+++ b/sonar.js
@@ -1,24 +1,287 @@
-(function (app) {
-  if (!app) {
-    return;
+(function (global) {
+  const GRID_SIZE = 5;
+  const SOLUTION_CELLS = [
+    '0-2',
+    '1-1',
+    '1-2',
+    '1-3',
+    '2-0',
+    '2-1',
+    '2-2',
+    '2-3',
+    '2-4',
+    '3-1',
+    '3-2',
+    '3-3',
+    '4-2',
+  ];
+  const ROW_TARGETS = [1, 3, 5, 3, 1];
+  const COLUMN_TARGETS = [1, 3, 5, 3, 1];
+  const SOLUTION_SET = new Set(SOLUTION_CELLS);
+  const KEYWORD = 'TORPEDO';
+
+  let app = null;
+  let registered = false;
+  let gridBuilt = false;
+  let gridElement = null;
+  let clueElement = null;
+  let successElement = null;
+  let successKeyword = null;
+  let solved = false;
+
+  function parseCellId(id) {
+    const [row, col] = id.split('-').map(Number);
+    return { row, col };
   }
 
-  function initPuzzle() {
-    // Placeholder for sonar shape sequence initialisation.
+  function collectState() {
+    const rowCounts = Array(GRID_SIZE).fill(0);
+    const columnCounts = Array(GRID_SIZE).fill(0);
+    const activeIds = [];
+
+    if (!gridElement) {
+      return { rowCounts, columnCounts, activeIds };
+    }
+
+    Array.from(gridElement.querySelectorAll('.sonar-cell.active')).forEach(cell => {
+      const id = cell.dataset.cell;
+      if (!id) return;
+      const { row, col } = parseCellId(id);
+      if (Number.isInteger(row) && Number.isInteger(col)) {
+        rowCounts[row] += 1;
+        columnCounts[col] += 1;
+        activeIds.push(id);
+      }
+    });
+
+    return { rowCounts, columnCounts, activeIds };
   }
 
-  function resetPuzzle() {
-    // Awaiting gameplay logic; nothing to reset yet.
+  function updateClueStatus(additionalMessage = '', state = null) {
+    if (!clueElement) {
+      return;
+    }
+
+    const current = state ?? collectState();
+    const rowStatus = ROW_TARGETS.map((target, index) => `${current.rowCounts[index]}/${target}`).join('  |  ');
+    const columnStatus = COLUMN_TARGETS.map((target, index) => `${current.columnCounts[index]}/${target}`).join('  |  ');
+
+    let html = `<strong>Row echoes</strong>: ${rowStatus}`;
+    html += `<br><strong>Column echoes</strong>: ${columnStatus}`;
+
+    if (additionalMessage) {
+      html += `<span class="sonar-alert">${additionalMessage}</span>`;
+    } else if (solved) {
+      html += '<span class="sonar-confirm">Contact confirmed.</span>';
+    }
+
+    clueElement.innerHTML = html;
   }
 
-  function revealHint() {
-    return '📡 Sonar Shapes: Array alignment in progress.';
+  function patternMatches(state) {
+    if (!state) {
+      return false;
+    }
+
+    if (state.activeIds.length !== SOLUTION_SET.size) {
+      return false;
+    }
+
+    for (let index = 0; index < GRID_SIZE; index += 1) {
+      if (state.rowCounts[index] !== ROW_TARGETS[index]) {
+        return false;
+      }
+      if (state.columnCounts[index] !== COLUMN_TARGETS[index]) {
+        return false;
+      }
+    }
+
+    return state.activeIds.every(id => SOLUTION_SET.has(id));
   }
 
-  app.registerPuzzle('sonar', {
-    init: initPuzzle,
-    reset: resetPuzzle,
-    reveal: revealHint,
-    description: 'Sonar Shapes',
-  });
-})(window.SubControls);
+  function markSolved(state = null) {
+    if (solved) {
+      updateClueStatus('', state ?? collectState());
+      return;
+    }
+
+    solved = true;
+
+    if (successElement) {
+      successElement.hidden = false;
+    }
+
+    if (successKeyword) {
+      successKeyword.textContent = KEYWORD;
+    }
+
+    if (app && typeof app.setKeywordBanner === 'function') {
+      app.setKeywordBanner(`📡 SIGNAL LOCKED: ${KEYWORD}`, 'sonar');
+    }
+
+    updateClueStatus('', state);
+  }
+
+  function handleCellToggle(event) {
+    if (solved || !gridElement) {
+      return;
+    }
+
+    const cell = event.currentTarget;
+    if (!(cell instanceof HTMLElement) || !cell.dataset.cell) {
+      return;
+    }
+
+    cell.classList.toggle('active');
+    const { row, col } = parseCellId(cell.dataset.cell);
+    const state = collectState();
+    const warnings = [];
+
+    if (state.rowCounts[row] > ROW_TARGETS[row]) {
+      warnings.push(`Row ${row + 1} echo limit reached.`);
+    }
+
+    if (state.columnCounts[col] > COLUMN_TARGETS[col]) {
+      warnings.push(`Column ${col + 1} echo limit reached.`);
+    }
+
+    if (warnings.length) {
+      cell.classList.toggle('active');
+      updateClueStatus(warnings.join(' '), collectState());
+      return;
+    }
+
+    if (patternMatches(state)) {
+      markSolved(state);
+      return;
+    }
+
+    updateClueStatus('', state);
+  }
+
+  function buildGrid() {
+    if (!gridElement) {
+      return;
+    }
+
+    gridElement.innerHTML = '';
+
+    for (let row = 0; row < GRID_SIZE; row += 1) {
+      for (let col = 0; col < GRID_SIZE; col += 1) {
+        const cell = global.document.createElement('button');
+        cell.type = 'button';
+        cell.className = 'sonar-cell';
+        cell.dataset.cell = `${row}-${col}`;
+        cell.setAttribute('aria-label', `Row ${row + 1}, Column ${col + 1}`);
+        cell.addEventListener('click', handleCellToggle);
+        gridElement.appendChild(cell);
+      }
+    }
+
+    gridBuilt = true;
+  }
+
+  function ensureElements() {
+    const section = global.document?.getElementById('sonar');
+    if (!section) {
+      return false;
+    }
+
+    gridElement = section.querySelector('#sonar-grid');
+    clueElement = section.querySelector('#sonar-clue');
+    successElement = section.querySelector('#sonar-success');
+    successKeyword = section.querySelector('#sonar-keyword');
+
+    return Boolean(gridElement && clueElement && successElement && successKeyword);
+  }
+
+  function applyResetState() {
+    solved = false;
+
+    if (gridElement) {
+      Array.from(gridElement.querySelectorAll('.sonar-cell')).forEach(cell => {
+        cell.classList.remove('active');
+      });
+    }
+
+    if (successElement) {
+      successElement.hidden = true;
+    }
+
+    if (successKeyword) {
+      successKeyword.textContent = KEYWORD;
+    }
+
+    if (app && typeof app.clearKeywordBanner === 'function') {
+      app.clearKeywordBanner('sonar');
+    }
+
+    updateClueStatus();
+  }
+
+  function initializeSonarPuzzle() {
+    if (!ensureElements()) {
+      return;
+    }
+
+    buildGrid();
+    applyResetState();
+  }
+
+  function resetSonarPuzzle() {
+    if (!ensureElements()) {
+      return;
+    }
+
+    if (!gridBuilt) {
+      buildGrid();
+    }
+
+    applyResetState();
+  }
+
+  function revealSonarSolution() {
+    if (!ensureElements()) {
+      return '📡 Sonar Solution: Console offline.';
+    }
+
+    if (!gridBuilt) {
+      buildGrid();
+    }
+
+    Array.from(gridElement.querySelectorAll('.sonar-cell')).forEach(cell => {
+      const shouldActivate = cell.dataset.cell ? SOLUTION_SET.has(cell.dataset.cell) : false;
+      cell.classList.toggle('active', shouldActivate);
+    });
+
+    const state = collectState();
+    markSolved(state);
+
+    return `📡 Sonar Solution: ${KEYWORD} — rows ${ROW_TARGETS.join('/')}, columns ${COLUMN_TARGETS.join('/')}.`;
+  }
+
+  function attemptRegistration() {
+    if (registered) {
+      return;
+    }
+
+    if (global.SubControls && typeof global.SubControls.registerPuzzle === 'function') {
+      app = global.SubControls;
+      app.registerPuzzle('sonar', {
+        init: initializeSonarPuzzle,
+        reset: resetSonarPuzzle,
+        reveal: revealSonarSolution,
+        description: 'Sonar Shapes',
+      });
+      registered = true;
+    } else {
+      global.setTimeout(attemptRegistration, 40);
+    }
+  }
+
+  attemptRegistration();
+
+  global.initializeSonarPuzzle = initializeSonarPuzzle;
+  global.resetSonarPuzzle = resetSonarPuzzle;
+  global.revealSonarSolution = revealSonarSolution;
+})(window);

--- a/style.css
+++ b/style.css
@@ -557,3 +557,93 @@ section.active {
     height: 110px;
   }
 }
+
+.sonar-console {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  align-items: center;
+  text-align: center;
+}
+
+.sonar-description {
+  max-width: 32rem;
+  margin: 0 auto;
+  color: rgba(202, 240, 248, 0.85);
+}
+
+.sonar-grid {
+  display: grid;
+  grid-template-columns: repeat(5, 3rem);
+  gap: 0.75rem;
+  padding: 1rem;
+  background: rgba(1, 22, 39, 0.6);
+  border: 1px solid rgba(72, 202, 228, 0.35);
+  border-radius: 0.75rem;
+  box-shadow: inset 0 0 18px rgba(0, 119, 182, 0.25);
+}
+
+.sonar-cell {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
+  border: 1px solid rgba(72, 202, 228, 0.4);
+  background: radial-gradient(circle at 35% 35%, rgba(144, 224, 239, 0.18), rgba(1, 22, 39, 0.9));
+  box-shadow: 0 0 8px rgba(72, 202, 228, 0.25);
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
+  color: transparent;
+}
+
+.sonar-cell:hover {
+  box-shadow: 0 0 10px rgba(72, 202, 228, 0.35);
+  transform: translateY(-2px);
+}
+
+.sonar-cell:focus-visible {
+  outline: 2px solid #ffd166;
+  outline-offset: 2px;
+}
+
+.sonar-cell.active {
+  background: radial-gradient(circle at 40% 40%, #90e0ef, #00b4d8 55%, #03045e 100%);
+  box-shadow: 0 0 18px rgba(144, 224, 239, 0.65);
+}
+
+.sonar-clue {
+  margin: 0;
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: #ade8f4;
+}
+
+.sonar-clue .sonar-alert {
+  display: block;
+  margin-top: 0.5rem;
+  color: #ffd166;
+  font-weight: 600;
+}
+
+.sonar-clue .sonar-confirm {
+  display: block;
+  margin-top: 0.5rem;
+  color: #9ef01a;
+  font-weight: 600;
+}
+
+.sonar-success {
+  background: rgba(72, 201, 176, 0.15);
+  border: 1px solid rgba(72, 201, 176, 0.5);
+  border-radius: 0.75rem;
+  padding: 0.75rem 1.25rem;
+  box-shadow: 0 0 16px rgba(72, 201, 176, 0.3);
+  color: #b7efc5;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.sonar-success strong {
+  color: #d8f3dc;
+  margin-right: 0.5rem;
+}

--- a/utils.js
+++ b/utils.js
@@ -9,6 +9,18 @@
   const devOutput = document.getElementById('dev-output');
   let keywordOwner = null;
 
+  function onDocumentReady(callback) {
+    if (typeof callback !== 'function') {
+      return;
+    }
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', callback, { once: true });
+    } else {
+      callback();
+    }
+  }
+
   function activateTab(targetId) {
     const buttons = Array.from(document.querySelectorAll('nav .tab'));
     const sections = Array.from(document.querySelectorAll('section'));
@@ -52,7 +64,7 @@
     puzzles.set(id, entry);
 
     if (typeof entry.init === 'function') {
-      entry.init();
+      onDocumentReady(() => entry.init());
     }
   }
 
@@ -115,7 +127,7 @@
     return keywordBanner;
   }
 
-  setupTabs();
+  onDocumentReady(setupTabs);
 
   const api = {
     registerPuzzle,


### PR DESCRIPTION
## Summary
- replace the Sonar Shapes placeholder with a narrative console, clues, and keyword banner
- style the sonar grid so its pips fit the existing nautical palette
- implement the sonar puzzle logic and hook it into the shared init/reset/reveal flow

## Testing
- Not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68d088aca86883258e71e0042dcda4a3