### PR TITLE
Add undo interaction to Control Unlock puzzle

### DIFF
--- a/style.css
+++ b/style.css
@@ -545,6 +545,15 @@ section.active {
   border-style: solid;
 }
 
+.guess-slot.undoable {
+  cursor: pointer;
+  box-shadow: 0 0 6px rgba(173, 232, 244, 0.6);
+}
+
+.guess-slot.undoable:active {
+  transform: scale(0.95);
+}
+
 .score-box {
   width: 2.5rem;
   margin-left: 0.5rem;


### PR DESCRIPTION
## Summary
- allow the newest peg in the active row to be clicked to remove it before submitting a guess
- cancel any pending guess validation when undoing and guard against incomplete rows being scored
- highlight undoable pegs with pointer feedback for clarity

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d08e0ccbbc8325913b7c752354dd46