### PR TITLE
Add reset and reveal hook support for puzzles

### DIFF
--- a/control-unlock.js
+++ b/control-unlock.js
@@ -245,38 +245,37 @@
     resetPuzzle();
   }
 
-  function enhancePortholeIntegration() {
-    const originalReset = window.resetGame;
-    const originalReveal = window.revealSolution;
-
+  function ensurePortholeHooks() {
     document.addEventListener('DOMContentLoaded', () => {
       if (typeof window.initializePortholePuzzle === 'function') {
         window.initializePortholePuzzle();
       }
     });
 
-    window.resetGame = function (...args) {
-      if (typeof originalReset === 'function') {
-        originalReset.apply(this, args);
+    if (typeof app.registerResetHook === 'function') {
+      if (!app.__portholeResetHook) {
+        app.__portholeResetHook = () => {
+          if (typeof window.resetPortholePuzzle === 'function') {
+            window.resetPortholePuzzle();
+          }
+        };
       }
-      if (typeof window.resetPortholePuzzle === 'function') {
-        window.resetPortholePuzzle();
+      app.registerResetHook(app.__portholeResetHook);
+    }
+
+    if (typeof app.registerRevealHook === 'function') {
+      if (!app.__portholeRevealHook) {
+        app.__portholeRevealHook = () => {
+          if (typeof window.revealPortholeSolution === 'function') {
+            window.revealPortholeSolution();
+          }
+        };
       }
-    };
-
-    window.revealSolution = function (...args) {
-      const result =
-        typeof originalReveal === 'function' ? originalReveal.apply(this, args) : undefined;
-
-      if (typeof window.revealPortholeSolution === 'function') {
-        window.revealPortholeSolution();
-      }
-
-      return result;
-    };
+      app.registerRevealHook(app.__portholeRevealHook);
+    }
   }
 
-  enhancePortholeIntegration();
+  ensurePortholeHooks();
 
   app.registerPuzzle('control-unlock', {
     init: initPuzzle,

--- a/porthole.js
+++ b/porthole.js
@@ -269,4 +269,24 @@
   global.initializePortholePuzzle = initialisePuzzle;
   global.resetPortholePuzzle = resetPuzzle;
   global.revealPortholeSolution = revealPuzzle;
+
+  if (global.SubControls) {
+    const sc = global.SubControls;
+
+    if (typeof sc.unregisterResetHook === 'function' && sc.__portholeResetHook) {
+      sc.unregisterResetHook(sc.__portholeResetHook);
+    }
+    if (typeof sc.registerResetHook === 'function') {
+      sc.__portholeResetHook = resetPuzzle;
+      sc.registerResetHook(resetPuzzle);
+    }
+
+    if (typeof sc.unregisterRevealHook === 'function' && sc.__portholeRevealHook) {
+      sc.unregisterRevealHook(sc.__portholeRevealHook);
+    }
+    if (typeof sc.registerRevealHook === 'function') {
+      sc.__portholeRevealHook = revealPuzzle;
+      sc.registerRevealHook(revealPuzzle);
+    }
+  }
 })(window);

--- a/spot-diff.js
+++ b/spot-diff.js
@@ -5,6 +5,34 @@
 
   const KEYWORD = 'PERISCOPE';
 
+  function ensurePortholeHooks() {
+    if (typeof app.registerResetHook === 'function') {
+      if (!app.__portholeResetHook) {
+        app.__portholeResetHook = () => {
+          const reset = window.resetPortholePuzzle;
+          if (typeof reset === 'function') {
+            reset();
+          }
+        };
+      }
+      app.registerResetHook(app.__portholeResetHook);
+    }
+
+    if (typeof app.registerRevealHook === 'function') {
+      if (!app.__portholeRevealHook) {
+        app.__portholeRevealHook = () => {
+          const reveal = window.revealPortholeSolution;
+          if (typeof reveal === 'function') {
+            reveal();
+          }
+        };
+      }
+      app.registerRevealHook(app.__portholeRevealHook);
+    }
+  }
+
+  ensurePortholeHooks();
+
   function callIfAvailable(handlerName) {
     const handler = window[handlerName];
     if (typeof handler === 'function') {
@@ -17,11 +45,18 @@
   }
 
   function resetPuzzle() {
+    const reset = window.resetPortholePuzzle;
+    if (typeof reset === 'function' && app && app.__portholeResetHook === reset) {
+      return;
+    }
     callIfAvailable('resetPortholePuzzle');
   }
 
   function revealHint() {
-    callIfAvailable('revealPortholeSolution');
+    const reveal = window.revealPortholeSolution;
+    if (!(typeof reveal === 'function' && app && app.__portholeRevealHook === reveal)) {
+      callIfAvailable('revealPortholeSolution');
+    }
     return `🔍 Porthole Puzzle Keyword: ${KEYWORD}`;
   }
 

--- a/utils.js
+++ b/utils.js
@@ -4,6 +4,8 @@
   }
 
   const puzzles = new Map();
+  const resetHooks = new Set();
+  const revealHooks = new Set();
   const keywordBanner = document.getElementById('keyword-banner');
   const devTools = document.getElementById('dev-tools');
   const devOutput = document.getElementById('dev-output');
@@ -68,9 +70,57 @@
     }
   }
 
+  function invokeHooks(collection) {
+    collection.forEach(handler => {
+      try {
+        handler();
+      } catch (error) {
+        console.error('SubControls hook error:', error);
+      }
+    });
+  }
+
+  function registerHook(collection, handler) {
+    if (typeof handler !== 'function') {
+      return () => {};
+    }
+
+    collection.add(handler);
+
+    return () => {
+      collection.delete(handler);
+    };
+  }
+
+  function unregisterHook(collection, handler) {
+    if (typeof handler !== 'function') {
+      return;
+    }
+
+    collection.delete(handler);
+  }
+
+  function registerResetHook(handler) {
+    return registerHook(resetHooks, handler);
+  }
+
+  function registerRevealHook(handler) {
+    return registerHook(revealHooks, handler);
+  }
+
+  function unregisterResetHook(handler) {
+    unregisterHook(resetHooks, handler);
+  }
+
+  function unregisterRevealHook(handler) {
+    unregisterHook(revealHooks, handler);
+  }
+
   function resetAllPuzzles() {
     clearKeywordBanner();
     setDevOutput('');
+
+    invokeHooks(resetHooks);
 
     puzzles.forEach(entry => {
       if (typeof entry.reset === 'function') {
@@ -81,6 +131,8 @@
 
   function revealAllSolutions() {
     const sections = [];
+
+    invokeHooks(revealHooks);
 
     puzzles.forEach((entry, id) => {
       if (typeof entry.reveal === 'function') {
@@ -139,6 +191,10 @@
     setDevOutput,
     getDevOutputElement,
     getKeywordBannerElement,
+    registerResetHook,
+    registerRevealHook,
+    unregisterResetHook,
+    unregisterRevealHook,
   };
 
   global.SubControls = Object.assign(global.SubControls || {}, api);


### PR DESCRIPTION
## Summary
- add a reset/reveal hook registry in `utils.js` so callers can subscribe or unsubscribe without patching globals
- update the Control Unlock and Spot the Difference puzzles to register porthole reset/reveal hooks through the new API
- register the porthole puzzle handlers with the hook API so the shared wrappers are replaced with the live implementations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d91ba6e1488325acffa86a840b8c9f