### PR TITLE
Add Playwright end-to-end testing harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,28 @@ To deploy:
 
 ---
 
+## 🤖 Automated Testing
+
+End-to-end coverage is available via [Playwright](https://playwright.dev/). The tests boot a lightweight static server, exercise
+each puzzle using the exposed `SubControls` hooks, and confirm that the correct keywords appear in the UI.
+
+1. Install the dev dependencies:
+   ```bash
+   npm install
+   ```
+2. Install the supported Playwright browsers (only required once per environment):
+   ```bash
+   npx playwright install --with-deps
+   ```
+3. Run the full suite:
+   ```bash
+   npx playwright test
+   ```
+
+The configuration lives in `playwright.config.js` and uses `scripts/dev-server.js` to serve the project root during test runs.
+
+---
+
 ## 💡 Inspirations
 
 - Classic codebreaking logic puzzles (e.g., [this board game](https://en.wikipedia.org/wiki/Mastermind_(board_game)))

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "sub-controls",
+  "private": true,
+  "version": "0.0.0",
+  "description": "End-to-end test harness for the Sub-Controls puzzles.",
+  "scripts": {
+    "serve": "node scripts/dev-server.js",
+    "test:e2e": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.44.1"
+  }
+}

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,30 @@
+// @ts-check
+const { defineConfig, devices } = require('@playwright/test');
+
+const PORT = Number(process.env.PORT || 4173);
+const BASE_URL = `http://127.0.0.1:${PORT}`;
+
+module.exports = defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: false,
+  retries: process.env.CI ? 2 : 0,
+  timeout: 30 * 1000,
+  use: {
+    baseURL: BASE_URL,
+    trace: 'on-first-retry'
+  },
+  webServer: {
+    command: 'node scripts/dev-server.js',
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    timeout: 10 * 1000
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] }
+    }
+  ]
+});

--- a/scripts/dev-server.js
+++ b/scripts/dev-server.js
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const { URL } = require('url');
+
+const rootDir = path.resolve(__dirname, '..');
+const port = Number(process.env.PORT || 4173);
+
+const MIME_TYPES = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.ico': 'image/x-icon',
+  '.txt': 'text/plain; charset=utf-8'
+};
+
+function resolvePath(requestPath) {
+  let relativePath = decodeURIComponent(requestPath.split('?')[0]);
+  if (relativePath.endsWith('/')) {
+    relativePath = path.join(relativePath, 'index.html');
+  }
+  const resolved = path.join(rootDir, relativePath);
+  if (!resolved.startsWith(rootDir)) {
+    return null;
+  }
+  return resolved;
+}
+
+function sendFile(res, filePath) {
+  fs.stat(filePath, (statErr, stats) => {
+    if (statErr || !stats.isFile()) {
+      sendNotFound(res);
+      return;
+    }
+
+    const ext = path.extname(filePath).toLowerCase();
+    const mime = MIME_TYPES[ext] || 'application/octet-stream';
+
+    res.writeHead(200, {
+      'Content-Type': mime,
+      'Content-Length': stats.size,
+      'Cache-Control': 'no-cache'
+    });
+
+    const stream = fs.createReadStream(filePath);
+    stream.on('error', () => sendServerError(res));
+    stream.pipe(res);
+  });
+}
+
+function sendNotFound(res) {
+  res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+  res.end('Not found');
+}
+
+function sendServerError(res) {
+  if (res.headersSent) {
+    res.end();
+    return;
+  }
+  res.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' });
+  res.end('Server error');
+}
+
+const server = http.createServer((req, res) => {
+  try {
+    const url = new URL(req.url, `http://${req.headers.host}`);
+    const filePath = resolvePath(url.pathname);
+    if (!filePath) {
+      sendNotFound(res);
+      return;
+    }
+    fs.access(filePath, fs.constants.F_OK, err => {
+      if (err) {
+        sendNotFound(res);
+        return;
+      }
+      sendFile(res, filePath);
+    });
+  } catch (error) {
+    sendServerError(res);
+  }
+});
+
+server.listen(port, () => {
+  // eslint-disable-next-line no-console
+  console.log(`Static server running at http://127.0.0.1:${port}`);
+});

--- a/tests/e2e/ballast.spec.js
+++ b/tests/e2e/ballast.spec.js
@@ -1,0 +1,36 @@
+const { test, expect } = require('@playwright/test');
+
+test('ballast puzzle helpers balance the submarine', async ({ page }) => {
+  await page.goto('/');
+  await page.click('nav .tab[data-target="ballast"]');
+
+  const solution = await page.evaluate(() => {
+    const config = window.SubControls.getBallastConfig();
+    const offsets = [];
+    for (let a = config.slider.minOffset; a <= config.slider.maxOffset; a += 1) {
+      for (let b = config.slider.minOffset; b <= config.slider.maxOffset; b += 1) {
+        for (let c = config.slider.minOffset; c <= config.slider.maxOffset; c += 1) {
+          for (let d = config.slider.minOffset; d <= config.slider.maxOffset; d += 1) {
+            const candidate = [a, b, c, d];
+            const result = window.SubControls.simulateBallast(candidate, 1);
+            if (result.tilt === 0 && result.depth === 0) {
+              return { offsets: candidate, polarity: 1 };
+            }
+          }
+        }
+      }
+    }
+    return null;
+  });
+
+  if (!solution) {
+    throw new Error('No ballast solution found');
+  }
+
+  await page.evaluate(options => {
+    window.SubControls.setBallastControls({ ...options, autoConfirm: true });
+  }, solution);
+
+  await expect(page.locator('#ballast-outcome')).toContainText('keyword TRIM');
+  await expect(page.locator('#keyword-banner')).toContainText('TRIM');
+});

--- a/tests/e2e/control-unlock.spec.js
+++ b/tests/e2e/control-unlock.spec.js
@@ -1,0 +1,32 @@
+const { test, expect } = require('@playwright/test');
+
+const COLOR_INDEX = {
+  red: 0,
+  blue: 1,
+  green: 2,
+  yellow: 3,
+  purple: 4,
+  orange: 5
+};
+
+const SOLUTION = ['red', 'blue', 'green', 'yellow'];
+
+const KEYWORD = 'RUDDER';
+
+test('control unlock puzzle can be solved deterministically', async ({ page }) => {
+  await page.goto('/');
+
+  await page.evaluate(({ solution, keyword }) => {
+    window.SubControls.setControlUnlockState({ solution, keyword, apply: true });
+  }, { solution: SOLUTION, keyword: KEYWORD });
+
+  for (const color of SOLUTION) {
+    const index = COLOR_INDEX[color];
+    await page.locator('#color-picker .peg').nth(index).click();
+  }
+
+  await page.waitForTimeout(600);
+
+  await expect(page.locator('#puzzle-box')).toContainText(KEYWORD);
+  await expect(page.locator('#keyword-banner')).toContainText(KEYWORD);
+});

--- a/tests/e2e/navigation.spec.js
+++ b/tests/e2e/navigation.spec.js
@@ -1,0 +1,38 @@
+const { test, expect } = require('@playwright/test');
+
+test('navigation riddle gates hints and confirms the correct keyword', async ({ page }) => {
+  await page.goto('/');
+  await page.click('nav .tab[data-target="navigation"]');
+
+  const firstHintButton = page.locator('.nav-hint-toggle[data-hint="nav-hint-1"]');
+  const secondHintButton = page.locator('.nav-hint-toggle[data-hint="nav-hint-2"]');
+  const firstHint = page.locator('#nav-hint-1');
+  const secondHint = page.locator('#nav-hint-2');
+  const answerInput = page.locator('#nav-answer');
+  const submitButton = page.locator('#nav-submit');
+  const feedback = page.locator('#nav-feedback');
+
+  await expect(firstHintButton).toBeEnabled();
+  await firstHintButton.click();
+  await expect(firstHint).toBeVisible();
+
+  await expect(secondHintButton).toBeDisabled();
+
+  for (const guess of ['WRONG', 'AGAIN']) {
+    await answerInput.fill(guess);
+    await submitButton.click();
+    await expect(feedback).toContainText('heading drifts off-course');
+    await page.waitForTimeout(800);
+  }
+
+  await expect(secondHintButton).toBeEnabled();
+  await secondHintButton.click();
+  await expect(secondHint).toBeVisible();
+
+  await answerInput.fill('CHART');
+  await submitButton.click();
+
+  await expect(page.locator('#nav-success')).toHaveClass(/visible/);
+  await expect(page.locator('#keyword-banner')).toContainText('CHART');
+  await expect(answerInput).toHaveAttribute('readonly', 'readonly');
+});

--- a/tests/e2e/porthole.spec.js
+++ b/tests/e2e/porthole.spec.js
@@ -1,0 +1,25 @@
+const { test, expect } = require('@playwright/test');
+
+test('porthole puzzle reveals keyword after marking all differences', async ({ page }) => {
+  await page.goto('/');
+  await page.click('nav .tab[data-target="spot-diff"]');
+
+  await page.waitForSelector('.difference-marker');
+
+  const differenceIds = await page.evaluate(() => {
+    return Array.from(
+      new Set(
+        Array.from(document.querySelectorAll('.difference-marker')).map(el => el.dataset.differenceId)
+      )
+    ).filter(Boolean);
+  });
+
+  for (const id of differenceIds) {
+    await page.locator(`.difference-marker[data-difference-id="${id}"]`).first().click();
+  }
+
+  const successBanner = page.locator('#porthole-success');
+  await expect(successBanner).toHaveClass(/visible/);
+  await expect(page.locator('#porthole-keyword')).toHaveText('PERISCOPE');
+  await expect(page.locator('#keyword-banner')).toContainText('PERISCOPE');
+});

--- a/tests/e2e/sonar.spec.js
+++ b/tests/e2e/sonar.spec.js
@@ -1,0 +1,21 @@
+const { test, expect } = require('@playwright/test');
+
+const CUSTOM_LAYOUT = ['0-0', '0-1', '1-0'];
+const SONAR_KEYWORD = 'PING';
+
+test('sonar puzzle recognises a scripted contact layout', async ({ page }) => {
+  await page.goto('/');
+  await page.click('nav .tab[data-target="sonar"]');
+
+  await page.evaluate(({ layout, keyword }) => {
+    window.SubControls.setSonarState({ layout, keyword, apply: true });
+  }, { layout: CUSTOM_LAYOUT, keyword: SONAR_KEYWORD });
+
+  for (const cellId of CUSTOM_LAYOUT) {
+    await page.locator(`.sonar-cell[data-cell="${cellId}"]`).click();
+  }
+
+  await expect(page.locator('#sonar-success')).toBeVisible();
+  await expect(page.locator('#sonar-keyword')).toHaveText(SONAR_KEYWORD);
+  await expect(page.locator('#keyword-banner')).toContainText(SONAR_KEYWORD);
+});


### PR DESCRIPTION
## Summary
- add a minimal package.json with Playwright and scripts for serving and running e2e tests
- configure Playwright to spin up a static server and target the existing puzzle views
- cover each puzzle with deterministic end-to-end specs and document the workflow in the README

## Testing
- npm install *(fails: 403 Forbidden from registry)*
- npx playwright test *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d9c616b54c8325b224971956c67005