### PR TITLE
Add mission briefing landing page with task links

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
   </header>
   <nav>
     <div id="keyword-banner"></div>
+    <button class="tab" data-target="mission">🛳️ Mission Briefing</button>
     <button class="tab" data-target="control-unlock">⚓ Control Unlock</button>
     <button class="tab" data-target="spot-diff">🔍 Porthole Puzzle</button>
     <button class="tab" data-target="ballast">⚖️ Ballast Balance</button>
@@ -26,7 +27,43 @@
     <div id="dev-output"></div>
   </div>
 
-  <section id="control-unlock" class="active">
+  <section id="mission" class="active">
+    <div class="content-box mission-briefing">
+      <h2>🛳️ Mission Briefing</h2>
+      <p class="mission-intro">
+        Welcome aboard, captain! Choose a station to tackle the submarine's challenges. Each mission earns a piece of the final keyword—select a task below to dive in.
+      </p>
+      <div class="task-grid">
+        <article class="task-card">
+          <h3><span class="task-emoji" aria-hidden="true">⚓</span> Control Unlock</h3>
+          <p>Break the crew's four-signal code before attempts run out to unlock the control console.</p>
+          <a href="#control-unlock" class="task-link" data-target="control-unlock">Enter Control Unlock</a>
+        </article>
+        <article class="task-card">
+          <h3><span class="task-emoji" aria-hidden="true">🔍</span> Porthole Puzzle</h3>
+          <p>Study the twin observation windows and mark every difference the lookouts missed.</p>
+          <a href="#spot-diff" class="task-link" data-target="spot-diff">Inspect the Portholes</a>
+        </article>
+        <article class="task-card">
+          <h3><span class="task-emoji" aria-hidden="true">⚖️</span> Ballast Balance</h3>
+          <p>Tune the ballast levers and polarity switch to stabilize the vessel before alarms flare.</p>
+          <a href="#ballast" class="task-link" data-target="ballast">Trim the Ballast</a>
+        </article>
+        <article class="task-card">
+          <h3><span class="task-emoji" aria-hidden="true">📡</span> Sonar Shapes</h3>
+          <p>Decode the sonar echoes by matching the incoming patterns to the correct formation.</p>
+          <a href="#sonar" class="task-link" data-target="sonar">Scan with Sonar</a>
+        </article>
+        <article class="task-card">
+          <h3><span class="task-emoji" aria-hidden="true">🗺️</span> Navigation Riddle</h3>
+          <p>Solve the charting riddle to plot a safe route through the cavernous trenches ahead.</p>
+          <a href="#navigation" class="task-link" data-target="navigation">Chart the Course</a>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <section id="control-unlock">
     <div class="content-box" id="puzzle-box">
       <h2>⚓ Control Unlock</h2>
       <p>Guess the hidden 4-color signal used by the submarine crew to unlock the vault. You have 10 tries to break the code!</p>

--- a/style.css
+++ b/style.css
@@ -69,6 +69,71 @@ section.active {
   box-shadow: 0 0 10px #0077b6;
 }
 
+.mission-briefing {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.mission-intro {
+  margin: 0;
+  color: rgba(202, 240, 248, 0.85);
+}
+
+.task-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.task-card {
+  background: rgba(2, 62, 138, 0.45);
+  border: 1px solid rgba(72, 202, 228, 0.4);
+  border-radius: 0.5rem;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  box-shadow: 0 0 12px rgba(0, 119, 182, 0.2);
+}
+
+.task-card h3 {
+  margin: 0;
+  font-size: 1.15rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: #90e0ef;
+}
+
+.task-card p {
+  margin: 0;
+  color: rgba(202, 240, 248, 0.8);
+}
+
+.task-link {
+  margin-top: auto;
+  align-self: flex-start;
+  text-decoration: none;
+  color: #ffd166;
+  font-weight: 600;
+  background: rgba(255, 209, 102, 0.12);
+  border: 1px solid rgba(255, 209, 102, 0.4);
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.task-link:hover,
+.task-link:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 0 12px rgba(255, 209, 102, 0.4);
+}
+
+.task-emoji {
+  font-size: 1.5rem;
+}
+
 .placeholder {
   text-align: center;
   font-style: italic;

--- a/utils.js
+++ b/utils.js
@@ -73,6 +73,24 @@
     }
   }
 
+  function setupTaskLinks() {
+    const doc = getDocument();
+    if (!doc) {
+      return;
+    }
+
+    const links = Array.from(doc.querySelectorAll('.task-link[data-target]'));
+    links.forEach(link => {
+      link.addEventListener('click', event => {
+        event.preventDefault();
+        const targetId = link.dataset.target;
+        if (targetId) {
+          activateTab(targetId);
+        }
+      });
+    });
+  }
+
   function registerPuzzle(id, handlers) {
     if (!id) {
       throw new Error('Puzzle id is required when registering a puzzle.');
@@ -264,6 +282,7 @@
   onDocumentReady(() => {
     primeDomCaches();
     setupTabs();
+    setupTaskLinks();
   });
 
   const api = {


### PR DESCRIPTION
## Summary
- add a mission briefing landing section that describes each puzzle and links to it
- style the landing cards with emoji highlights consistent with the theme
- update the tab logic so landing links activate the matching puzzle section

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d9d3461c3883259ab56adc1200145c