### PR TITLE
Improve sonar puzzle grid with visual readouts

### DIFF
--- a/index.html
+++ b/index.html
@@ -220,12 +220,18 @@
         <div>
           <h2>📡 Sonar Shapes</h2>
           <p class="sonar-description">
-            Cycle the pings to trace the contact silhouette. The row and column readouts show how many sonar pips should glow in
-            each line—overcharge a lane and the console will refuse the input.
+            Cycle the pings to trace the contact silhouette. Fill each meter without exceeding the target pings shown beside the
+            grid.
           </p>
         </div>
-        <div class="sonar-grid" id="sonar-grid" role="grid" aria-label="Sonar targeting grid"></div>
-        <p class="sonar-clue" id="sonar-clue"></p>
+        <div class="sonar-board" aria-label="Sonar targeting grid">
+          <div class="sonar-axis sonar-axis-columns" id="sonar-column-readouts"></div>
+          <div class="sonar-board-inner">
+            <div class="sonar-axis sonar-axis-rows" id="sonar-row-readouts"></div>
+            <div class="sonar-grid" id="sonar-grid" role="grid" aria-label="Sonar targeting grid"></div>
+          </div>
+        </div>
+        <p class="sonar-clue" id="sonar-clue" role="status" aria-live="polite"></p>
         <div class="sonar-success" id="sonar-success" hidden>
           <strong>Keyword detected:</strong> <span id="sonar-keyword">TORPEDO</span>
         </div>

--- a/sonar.js
+++ b/sonar.js
@@ -86,6 +86,8 @@
   let gridBuilt = false;
   let gridElement = null;
   let clueElement = null;
+  let rowReadoutElement = null;
+  let columnReadoutElement = null;
   let successElement = null;
   let successKeyword = null;
   let solved = false;
@@ -258,29 +260,75 @@
     return { rowCounts, columnCounts, activeIds };
   }
 
+  function renderAxisReadouts(container, currentCounts, targetCounts, axisLabelFormatter) {
+    if (!container) {
+      return;
+    }
+
+    const doc = container.ownerDocument;
+    container.innerHTML = '';
+
+    targetCounts.forEach((target, index) => {
+      const wrapper = doc.createElement('div');
+      wrapper.className = 'sonar-readout';
+
+      const label = doc.createElement('span');
+      label.className = 'sonar-readout-label';
+      label.textContent = axisLabelFormatter(index);
+
+      const meter = doc.createElement('div');
+      meter.className = 'sonar-readout-meter';
+      meter.setAttribute('role', 'meter');
+      meter.setAttribute('aria-valuemin', '0');
+      meter.setAttribute('aria-valuemax', String(Math.max(target, 1)));
+      meter.setAttribute('aria-valuenow', String(Math.min(currentCounts[index], Math.max(target, 1))));
+      meter.setAttribute('aria-label', `${axisLabelFormatter(index)} target ${target}`);
+
+      const fill = doc.createElement('div');
+      fill.className = 'sonar-readout-fill';
+      const fillRatio = target === 0 ? 0 : Math.min(1, currentCounts[index] / target);
+      fill.style.width = `${Math.max(0, Math.min(1, fillRatio)) * 100}%`;
+      meter.appendChild(fill);
+
+      const value = doc.createElement('span');
+      value.className = 'sonar-readout-value';
+      value.textContent = `${currentCounts[index]}/${target}`;
+
+      wrapper.appendChild(label);
+      wrapper.appendChild(meter);
+      wrapper.appendChild(value);
+      container.appendChild(wrapper);
+    });
+  }
+
   function updateClueStatus(additionalMessage = '', state = null) {
     if (!clueElement) {
       return;
     }
 
     const current = state ?? collectState();
-    const rowStatus = rowTargets
-      .map((target, index) => `${current.rowCounts[index]}/${target}`)
-      .join('  |  ');
-    const columnStatus = columnTargets
-      .map((target, index) => `${current.columnCounts[index]}/${target}`)
-      .join('  |  ');
+    renderAxisReadouts(rowReadoutElement, current.rowCounts, rowTargets, index => `Row ${index + 1}`);
+    renderAxisReadouts(columnReadoutElement, current.columnCounts, columnTargets, index => `Col ${index + 1}`);
 
-    let html = `<strong>Row echoes</strong>: ${rowStatus}`;
-    html += `<br><strong>Column echoes</strong>: ${columnStatus}`;
+    const doc = clueElement.ownerDocument;
+    clueElement.innerHTML = '';
+
+    const summary = doc.createElement('span');
+    summary.className = 'sonar-clue-summary';
+    summary.textContent = solved ? 'All echoes aligned.' : 'Fill every meter to match the incoming echoes.';
+    clueElement.appendChild(summary);
 
     if (additionalMessage) {
-      html += `<span class="sonar-alert">${additionalMessage}</span>`;
+      const alert = doc.createElement('span');
+      alert.className = 'sonar-alert';
+      alert.textContent = additionalMessage;
+      clueElement.appendChild(alert);
     } else if (solved) {
-      html += '<span class="sonar-confirm">Contact confirmed.</span>';
+      const confirm = doc.createElement('span');
+      confirm.className = 'sonar-confirm';
+      confirm.textContent = 'Contact confirmed.';
+      clueElement.appendChild(confirm);
     }
-
-    clueElement.innerHTML = html;
   }
 
   function patternMatches(state) {
@@ -394,10 +442,19 @@
 
     gridElement = section.querySelector('#sonar-grid');
     clueElement = section.querySelector('#sonar-clue');
+    rowReadoutElement = section.querySelector('#sonar-row-readouts');
+    columnReadoutElement = section.querySelector('#sonar-column-readouts');
     successElement = section.querySelector('#sonar-success');
     successKeyword = section.querySelector('#sonar-keyword');
 
-    return Boolean(gridElement && clueElement && successElement && successKeyword);
+    return Boolean(
+      gridElement &&
+      clueElement &&
+      rowReadoutElement &&
+      columnReadoutElement &&
+      successElement &&
+      successKeyword,
+    );
   }
 
   function applyResetState(reshuffle = false) {

--- a/style.css
+++ b/style.css
@@ -1316,6 +1316,93 @@ section.active {
   color: rgba(202, 240, 248, 0.85);
 }
 
+.sonar-board {
+  display: grid;
+  gap: 1rem;
+  justify-items: center;
+  width: max-content;
+}
+
+.sonar-board-inner {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.sonar-axis {
+  display: grid;
+  gap: 0.5rem;
+  color: #caf0f8;
+  font-family: 'Courier New', Courier, monospace;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.sonar-axis-columns {
+  grid-template-columns: repeat(5, minmax(3rem, 1fr));
+  justify-items: center;
+  width: 100%;
+}
+
+.sonar-axis-columns .sonar-readout {
+  flex-direction: column;
+  align-items: center;
+}
+
+.sonar-axis-rows {
+  grid-template-rows: repeat(5, 1fr);
+}
+
+.sonar-readout {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  opacity: 0.85;
+}
+
+.sonar-readout-label {
+  min-width: 3rem;
+  text-align: right;
+}
+
+.sonar-axis-columns .sonar-readout-label {
+  text-align: center;
+}
+
+.sonar-readout-meter {
+  position: relative;
+  flex: 1;
+  height: 0.4rem;
+  border-radius: 999px;
+  background: rgba(144, 224, 239, 0.2);
+  overflow: hidden;
+}
+
+.sonar-axis-columns .sonar-readout-meter {
+  width: 100%;
+}
+
+.sonar-readout-fill {
+  position: absolute;
+  inset: 0;
+  width: 0;
+  border-radius: inherit;
+  background: linear-gradient(90deg, rgba(0, 180, 216, 0.9), rgba(3, 4, 94, 0.9));
+  transition: width 0.2s ease;
+}
+
+.sonar-readout-value {
+  min-width: 3.5rem;
+  font-variant-numeric: tabular-nums;
+  text-align: left;
+}
+
+.sonar-axis-columns .sonar-readout-value {
+  text-align: center;
+}
+
 .sonar-grid {
   display: grid;
   grid-template-columns: repeat(5, 3rem);
@@ -1360,6 +1447,11 @@ section.active {
   font-size: 0.95rem;
   line-height: 1.5;
   color: #ade8f4;
+}
+
+.sonar-clue-summary {
+  display: block;
+  font-weight: 600;
 }
 
 .sonar-clue .sonar-alert {


### PR DESCRIPTION
## Summary
- restructure the sonar console markup to wrap the grid with row and column meters
- render dynamic readouts in the sonar logic and refresh the clue messaging for clarity
- add styling for the new meters to make the target counts visually legible

## Testing
- npm install *(fails: 403 Forbidden when fetching @playwright/test)*

------
https://chatgpt.com/codex/tasks/task_e_68d9d4844a94832593e8b1e26f56dd22