### PR TITLE
Enable per-puzzle Playwright projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,12 @@ each puzzle using the exposed `SubControls` hooks, and confirm that the correct 
    npx playwright test
    ```
 
+   To focus on a single puzzle, target its dedicated project:
+   ```bash
+   npx playwright test --project navigation
+   ```
+   Available project names: `ballast`, `control-unlock`, `navigation`, `porthole`, and `sonar`.
+
 The configuration lives in `playwright.config.js` and uses `scripts/dev-server.js` to serve the project root during test runs.
 
 ---

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -22,9 +22,14 @@ module.exports = defineConfig({
     timeout: 10 * 1000
   },
   projects: [
-    {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'] }
-    }
-  ]
+    'ballast',
+    'control-unlock',
+    'navigation',
+    'porthole',
+    'sonar'
+  ].map((name) => ({
+    name,
+    testMatch: `**/${name}.spec.js`,
+    use: { ...devices['Desktop Chrome'] }
+  }))
 });


### PR DESCRIPTION
## Summary
- configure Playwright to expose a dedicated project for each puzzle spec so they can run individually
- document the available project names and example usage for targeted Playwright runs

## Testing
- ⚠️ `npm install` *(fails: 403 Forbidden when requesting @playwright/test)*

------
https://chatgpt.com/codex/tasks/task_e_68d9d74b2e1883259929db1119c280f4