### PR TITLE
Add secret admin evaluation panel to dev tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,13 @@ Collected keywords can be used:
 - As D&D item codes
 - To open a hidden tab / secret area
 
+### 🔒 Secret Admin "Evaluate Score" Panel
+
+- Click the site header to toggle the developer tools overlay. The secret admin block lives directly inside that panel.
+- Each puzzle has a dropdown for recording status (`Unreviewed`, `Needs investigation`, `Verified ✅`). Update option text or add new stations in `index.html` under the `#admin-evaluate` container.
+- Styling is centralized in `style.css` (look for the `.admin-evaluate` rules). Add new selectors there when introducing tasks so the panel keeps its compact layout.
+- If a puzzle's success keyword changes, revise the accompanying description text to keep reviewers aligned on what the UI should display.
+
 ---
 
 ## 🧑‍💻 How to Run Locally

--- a/index.html
+++ b/index.html
@@ -24,6 +24,67 @@
     <strong>🛠️ Dev Tools</strong>
     <button onclick="resetGame()">🔄 Reset Puzzle</button>
     <button onclick="revealSolution()">👁️ Reveal Code</button>
+    <div id="admin-evaluate" class="admin-evaluate" aria-label="Secret admin evaluation panel">
+      <h3>Secret Admin · Evaluate Score</h3>
+      <p class="admin-intro">
+        Use these dropdowns to record your review of each station. Keyword notes explain what successful runs should display.
+      </p>
+      <div class="admin-task">
+        <label for="admin-control-unlock">Control Unlock</label>
+        <select id="admin-control-unlock" name="admin-control-unlock">
+          <option value="unreviewed" selected>Unreviewed</option>
+          <option value="needs-investigation">Needs investigation</option>
+          <option value="verified">Verified ✅</option>
+        </select>
+        <p class="admin-description">
+          <strong>Keywords:</strong> RUDDER, PERISCOPE, HELM, BALLAST — rotating crew signals that appear when the four-peg code is cracked.
+        </p>
+      </div>
+      <div class="admin-task">
+        <label for="admin-porthole">Porthole Puzzle</label>
+        <select id="admin-porthole" name="admin-porthole">
+          <option value="unreviewed" selected>Unreviewed</option>
+          <option value="needs-investigation">Needs investigation</option>
+          <option value="verified">Verified ✅</option>
+        </select>
+        <p class="admin-description">
+          <strong>Keyword:</strong> PERISCOPE — fires when every mismatch between the twin windows has been flagged.
+        </p>
+      </div>
+      <div class="admin-task">
+        <label for="admin-ballast">Ballast Balance</label>
+        <select id="admin-ballast" name="admin-ballast">
+          <option value="unreviewed" selected>Unreviewed</option>
+          <option value="needs-investigation">Needs investigation</option>
+          <option value="verified">Verified ✅</option>
+        </select>
+        <p class="admin-description">
+          <strong>Keyword:</strong> TRIM — confirms the levers and polarity toggle have stabilized the gauges and locked in the adjustments.
+        </p>
+      </div>
+      <div class="admin-task">
+        <label for="admin-sonar">Sonar Shapes</label>
+        <select id="admin-sonar" name="admin-sonar">
+          <option value="unreviewed" selected>Unreviewed</option>
+          <option value="needs-investigation">Needs investigation</option>
+          <option value="verified">Verified ✅</option>
+        </select>
+        <p class="admin-description">
+          <strong>Keyword:</strong> TORPEDO — shows the correct formation has been dialed in and relayed to the bridge.
+        </p>
+      </div>
+      <div class="admin-task">
+        <label for="admin-navigation">Navigation Riddle</label>
+        <select id="admin-navigation" name="admin-navigation">
+          <option value="unreviewed" selected>Unreviewed</option>
+          <option value="needs-investigation">Needs investigation</option>
+          <option value="verified">Verified ✅</option>
+        </select>
+        <p class="admin-description">
+          <strong>Keyword:</strong> CHART — lights up once the plotted route, pulse checks, and final transmission all match the course log.
+        </p>
+      </div>
+    </div>
     <div id="dev-output"></div>
   </div>
 

--- a/style.css
+++ b/style.css
@@ -665,6 +665,62 @@ section.active {
   font-size: 0.8rem;
 }
 
+.admin-evaluate {
+  margin-top: 0.75rem;
+  padding: 0.75rem;
+  background: rgba(10, 38, 71, 0.85);
+  border: 1px solid rgba(144, 224, 239, 0.35);
+  border-radius: 0.5rem;
+  display: grid;
+  gap: 0.75rem;
+  max-width: 18rem;
+}
+
+.admin-evaluate h3 {
+  margin: 0;
+  font-size: 1rem;
+  color: #90e0ef;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.admin-intro {
+  margin: 0;
+  color: #caf0f8;
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+
+.admin-task {
+  display: grid;
+  gap: 0.35rem;
+  background: rgba(0, 119, 182, 0.18);
+  border-radius: 0.4rem;
+  padding: 0.5rem;
+}
+
+.admin-task label {
+  font-weight: 600;
+  color: #ade8f4;
+  font-size: 0.85rem;
+}
+
+.admin-task select {
+  padding: 0.2rem 0.35rem;
+  font-size: 0.85rem;
+  background: #001d3d;
+  color: #f1f5f9;
+  border: 1px solid rgba(173, 232, 244, 0.4);
+  border-radius: 0.3rem;
+}
+
+.admin-description {
+  margin: 0;
+  color: #e0fbfc;
+  font-size: 0.75rem;
+  line-height: 1.5;
+}
+
 .ballast-panel {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- add a hidden admin evaluation block with dropdowns and keyword descriptions to the dev tools overlay
- style the panel to fit the nautical interface
- document how to update the secret admin area for future reviewers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9d71fbac48325a3b6e5b20b97870e