### PR TITLE
Fix sonar layout escaping mobile media query

### DIFF
--- a/style.css
+++ b/style.css
@@ -1357,7 +1357,7 @@ section.active {
   #nav-submit {
     width: 100%;
   }
-=======
+}
 .sonar-console {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- close the mobile navigation media query before the sonar styles
- remove stray merge artifact so sonar layout styles apply at all screen sizes

## Testing
- Verified layout in desktop and mobile viewports using Playwright screenshots

------
https://chatgpt.com/codex/tasks/task_e_68d9db4e00c4832599b0524db028bc7b