### PR TITLE
Refactor porthole puzzle to observation workflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
           <option value="verified">Verified ✅</option>
         </select>
         <p class="admin-description">
-          <strong>Keyword:</strong> PERISCOPE — fires when every mismatch between the twin windows has been flagged.
+          <strong>Keyword:</strong> PERISCOPE — fires when the correct anomaly from the still frame is logged after review.
         </p>
       </div>
       <div class="admin-task">
@@ -102,7 +102,7 @@
         </article>
         <article class="task-card">
           <h3><span class="task-emoji" aria-hidden="true">🔍</span> Porthole Puzzle</h3>
-          <p>Study the twin observation windows and mark every difference the lookouts missed.</p>
+          <p>Watch the baseline porthole feed and log the anomaly that appears in the follow-up still frame.</p>
           <a href="#spot-diff" class="task-link" data-target="spot-diff">Inspect the Portholes</a>
         </article>
         <article class="task-card">
@@ -139,56 +139,43 @@
         <div class="porthole-intro">
           <h2>🔍 Porthole Puzzle</h2>
           <p>
-            Two observation windows show the sea outside the submarine. Study the port and starboard scenes,
-            then tap every mismatch to flag it for the crew.
+            Study the baseline feed, then log the detail that shifts when the still frame appears. Tag the true
+            change to help the bridge track anomalies.
           </p>
+          <button type="button" class="porthole-observe-button" id="porthole-observe-button">
+            Observe
+          </button>
         </div>
-        <div class="porthole-scenes">
-          <div class="porthole-scene" data-scene="port">
-            <div class="porthole-frame">
-              <div class="porthole-glass" role="img" aria-label="Port observation porthole">
-                <div class="scene-detail hull"></div>
-                <div class="scene-detail tower"></div>
-                <div class="scene-detail viewport viewport-a"></div>
-                <div class="scene-detail viewport viewport-b"></div>
-                <div class="scene-detail viewport viewport-c"></div>
-                <div class="scene-detail buoy"></div>
-                <div class="scene-detail kelp kelp-port"></div>
-                <div class="scene-detail kelp kelp-starboard"></div>
-                <div class="scene-detail jellyfish"></div>
-                <div class="scene-detail sonar"></div>
-                <div class="scene-detail bubbles cluster-one"></div>
-                <div class="scene-detail bubbles cluster-two"></div>
-              </div>
-            </div>
-            <div class="porthole-label">Port Observation</div>
-          </div>
-          <div class="porthole-scene" data-scene="starboard">
-            <div class="porthole-frame">
-              <div class="porthole-glass" role="img" aria-label="Starboard observation porthole">
-                <div class="scene-detail hull"></div>
-                <div class="scene-detail tower"></div>
-                <div class="scene-detail viewport viewport-a"></div>
-                <div class="scene-detail viewport viewport-b"></div>
-                <div class="scene-detail viewport viewport-c"></div>
-                <div class="scene-detail buoy"></div>
-                <div class="scene-detail kelp kelp-port"></div>
-                <div class="scene-detail kelp kelp-starboard"></div>
-                <div class="scene-detail jellyfish"></div>
-                <div class="scene-detail sonar"></div>
-                <div class="scene-detail bubbles cluster-one"></div>
-                <div class="scene-detail bubbles cluster-two"></div>
-              </div>
-            </div>
-            <div class="porthole-label">Starboard Observation</div>
-          </div>
+        <div class="porthole-viewer">
+          <video
+            id="porthole-video"
+            class="porthole-video"
+            src="bubbles.mp4"
+            preload="auto"
+            playsinline
+            aria-label="Baseline porthole observation feed"
+          ></video>
+          <img
+            id="porthole-still"
+            class="porthole-still"
+            src=""
+            alt="Still frame awaiting observation"
+            hidden
+          />
         </div>
         <div class="porthole-progress" role="status" aria-live="polite">
-          Found <span id="porthole-found-count">0</span> of <span id="porthole-total-count">0</span> differences ·
-          <span class="porthole-progress-message" id="porthole-progress-message">Mark each mismatch to light the signal.</span>
+          <span class="porthole-progress-message" id="porthole-progress-message">
+            Press Observe to review the live feed.
+          </span>
         </div>
+        <form class="porthole-checklist" id="porthole-checklist" aria-live="polite">
+          <fieldset>
+            <legend>Log the detected change</legend>
+            <ul class="porthole-option-list" id="porthole-option-list"></ul>
+          </fieldset>
+        </form>
         <div class="porthole-success" id="porthole-success" aria-live="assertive">
-          <p>All differences spotted! Keyword:</p>
+          <p>Correct change logged! Keyword:</p>
           <p class="porthole-keyword" id="porthole-keyword"></p>
         </div>
       </div>

--- a/porthole.js
+++ b/porthole.js
@@ -1,81 +1,50 @@
 (function (global) {
   const KEYWORD = 'PERISCOPE';
 
-  const differences = [
+  const changes = [
     {
-      id: 'buoy-flag',
-      label: 'Signal buoy flag',
-      positions: {
-        port: { x: 28, y: 22 },
-        starboard: { x: 28, y: 22 },
-      },
-      found: false,
+      id: 'change1',
+      still: 'change1.webp',
+      alt: 'Still frame highlighting change scenario one.',
+      options: ['thing 1-1', 'thing 1-2', 'thing 1-3', 'thing 1-4'],
+      correctIndex: 0,
     },
     {
-      id: 'jellyfish-glow',
-      label: 'Glowing jellyfish',
-      positions: {
-        port: { x: 76, y: 36 },
-        starboard: { x: 76, y: 36 },
-      },
-      found: false,
+      id: 'change2',
+      still: 'change2.webp',
+      alt: 'Still frame highlighting change scenario two.',
+      options: ['thing 2-1', 'thing 2-2', 'thing 2-3', 'thing 2-4'],
+      correctIndex: 0,
     },
     {
-      id: 'sonar-ping',
-      label: 'Sonar pulse ring',
-      positions: {
-        port: { x: 50, y: 38 },
-        starboard: { x: 50, y: 38 },
-      },
-      found: false,
+      id: 'change3',
+      still: 'change3.webp',
+      alt: 'Still frame highlighting change scenario three.',
+      options: ['thing 3-1', 'thing 3-2', 'thing 3-3', 'thing 3-4'],
+      correctIndex: 0,
     },
     {
-      id: 'kelp-height',
-      label: 'Starboard kelp height',
-      positions: {
-        port: { x: 82, y: 70 },
-        starboard: { x: 82, y: 70 },
-      },
-      found: false,
-    },
-    {
-      id: 'vent-bubbles',
-      label: 'Vent bubble cluster',
-      positions: {
-        port: { x: 26, y: 68 },
-        starboard: { x: 26, y: 68 },
-      },
-      found: false,
-    },
-    {
-      id: 'extra-viewport',
-      label: 'Extra hull viewport',
-      positions: {
-        port: { x: 68, y: 60 },
-        starboard: { x: 68, y: 60 },
-      },
-      found: false,
+      id: 'change4',
+      still: 'change4.webp',
+      alt: 'Still frame highlighting change scenario four.',
+      options: ['thing 4-1', 'thing 4-2', 'thing 4-3', 'thing 4-4'],
+      correctIndex: 0,
     },
   ];
 
-  const differenceMap = new Map(differences.map(diff => [diff.id, diff]));
-
   const state = {
     container: null,
-    scenes: new Map(),
-    markers: new Map(),
-    progressCount: null,
-    totalCount: null,
+    observeButton: null,
+    video: null,
+    still: null,
     progressMessage: null,
     successBanner: null,
     keywordNode: null,
-    initialised: false,
-  };
-
-  const progressMessages = {
-    start: 'Mark each mismatch to light the signal.',
-    mid: 'Keep scanning the portholes for anomalies.',
-    complete: 'All differences logged. Signal ready to transmit.',
+    checklist: null,
+    optionList: null,
+    fieldset: null,
+    currentChange: null,
+    eventsBound: false,
   };
 
   function ensureElements() {
@@ -85,94 +54,173 @@
     }
 
     state.container = container;
-    state.progressCount = container.querySelector('#porthole-found-count');
-    state.totalCount = container.querySelector('#porthole-total-count');
+    state.observeButton = container.querySelector('#porthole-observe-button');
+    state.video = container.querySelector('#porthole-video');
+    state.still = container.querySelector('#porthole-still');
     state.progressMessage = container.querySelector('#porthole-progress-message');
     state.successBanner = container.querySelector('#porthole-success');
     state.keywordNode = container.querySelector('#porthole-keyword');
+    state.checklist = container.querySelector('#porthole-checklist');
+    state.optionList = container.querySelector('#porthole-option-list');
+    state.fieldset = state.checklist ? state.checklist.querySelector('fieldset') : null;
 
-    const portScene = container.querySelector('[data-scene="port"] .porthole-glass');
-    const starboardScene = container.querySelector('[data-scene="starboard"] .porthole-glass');
-
-    state.scenes.clear();
-    state.scenes.set('port', portScene);
-    state.scenes.set('starboard', starboardScene);
-
-    return Boolean(portScene && starboardScene);
+    return Boolean(
+      state.observeButton &&
+        state.video &&
+        state.still &&
+        state.progressMessage &&
+        state.successBanner &&
+        state.keywordNode &&
+        state.checklist &&
+        state.optionList
+    );
   }
 
-  function buildMarkers() {
-    state.markers.clear();
-
-    differences.forEach(diff => {
-      const markerSet = [];
-
-      Object.entries(diff.positions).forEach(([sceneKey, coords]) => {
-        const scene = state.scenes.get(sceneKey);
-        if (!scene) {
-          return;
-        }
-
-        const marker = document.createElement('button');
-        marker.type = 'button';
-        marker.className = 'difference-marker';
-        marker.dataset.differenceId = diff.id;
-        marker.dataset.scene = sceneKey;
-        marker.style.left = `${coords.x}%`;
-        marker.style.top = `${coords.y}%`;
-        marker.setAttribute('aria-label', `${diff.label}. Tap to toggle found state.`);
-        marker.setAttribute('aria-pressed', 'false');
-        marker.addEventListener('click', handleMarkerClick);
-        scene.appendChild(marker);
-        markerSet.push(marker);
-      });
-
-      state.markers.set(diff.id, markerSet);
-    });
-  }
-
-  function setMarkerState(diffId, found) {
-    const markerSet = state.markers.get(diffId);
-    if (!markerSet) {
+  function bindEvents() {
+    if (state.eventsBound) {
       return;
     }
 
-    markerSet.forEach(marker => {
-      marker.classList.toggle('found', found);
-      marker.setAttribute('aria-pressed', found ? 'true' : 'false');
+    if (!state.observeButton || !state.video || !state.checklist) {
+      return;
+    }
+
+    state.eventsBound = true;
+    state.observeButton.addEventListener('click', handleObserveClick);
+    state.video.addEventListener('ended', handleVideoEnded);
+    state.checklist.addEventListener('change', handleOptionSelection);
+  }
+
+  function handleObserveClick() {
+    if (!state.video || !state.observeButton) {
+      return;
+    }
+
+    hideSuccess();
+    state.currentChange = null;
+    setMessage('Playing baseline feed...');
+    setChecklistEnabled(false);
+    clearOptions();
+
+    state.video.hidden = false;
+    state.video.currentTime = 0;
+    state.video.pause();
+    state.video.play().catch(() => {
+      state.observeButton.disabled = false;
+      setMessage('Press Observe again to retry the baseline feed.');
+    });
+
+    if (state.still) {
+      state.still.hidden = true;
+      state.still.removeAttribute('src');
+      state.still.setAttribute('alt', 'Still frame awaiting observation');
+    }
+
+    state.observeButton.disabled = true;
+  }
+
+  function handleVideoEnded() {
+    state.observeButton.disabled = false;
+    displayRandomChange();
+  }
+
+  function displayRandomChange() {
+    if (!state.optionList || !state.video || !state.still) {
+      return;
+    }
+
+    const change = changes[Math.floor(Math.random() * changes.length)];
+    state.currentChange = change;
+
+    state.video.pause();
+    state.video.hidden = true;
+    state.video.currentTime = 0;
+
+    state.still.src = change.still;
+    state.still.alt = change.alt;
+    state.still.hidden = false;
+
+    populateOptions(change);
+    setChecklistEnabled(true);
+    if (state.observeButton) {
+      state.observeButton.disabled = false;
+    }
+    setMessage('Select the detail that changed from the list.');
+  }
+
+  function populateOptions(change) {
+    if (!state.optionList) {
+      return;
+    }
+
+    state.optionList.innerHTML = '';
+
+    change.options.forEach((label, index) => {
+      const optionId = `${change.id}-option-${index}`;
+      const listItem = document.createElement('li');
+      const checkbox = document.createElement('input');
+      checkbox.type = 'checkbox';
+      checkbox.id = optionId;
+      checkbox.name = 'porthole-option';
+      checkbox.value = String(index);
+      checkbox.dataset.correct = index === change.correctIndex ? 'true' : 'false';
+
+      const labelNode = document.createElement('label');
+      labelNode.setAttribute('for', optionId);
+      labelNode.textContent = label;
+
+      listItem.appendChild(checkbox);
+      listItem.appendChild(labelNode);
+      state.optionList.appendChild(listItem);
     });
   }
 
-  function countFound() {
-    return differences.reduce((total, diff) => (diff.found ? total + 1 : total), 0);
-  }
-
-  function updateProgress() {
-    const total = differences.length;
-    const foundCount = countFound();
-
-    if (state.progressCount) {
-      state.progressCount.textContent = String(foundCount);
+  function handleOptionSelection(event) {
+    const target = event.target;
+    if (!(target instanceof HTMLInputElement) || target.type !== 'checkbox') {
+      return;
     }
 
-    if (state.totalCount) {
-      state.totalCount.textContent = String(total);
+    if (state.fieldset && state.fieldset.disabled) {
+      target.checked = false;
+      return;
     }
 
-    if (state.progressMessage) {
-      let message = progressMessages.start;
-      if (foundCount === total && total > 0) {
-        message = progressMessages.complete;
-      } else if (foundCount > 0) {
-        message = progressMessages.mid;
+    if (!state.optionList) {
+      return;
+    }
+
+    const checkboxes = state.optionList.querySelectorAll("input[type='checkbox']");
+    checkboxes.forEach(box => {
+      if (box !== target) {
+        box.checked = false;
       }
-      state.progressMessage.textContent = message;
-    }
+    });
 
-    if (foundCount === total && total > 0) {
+    if (target.dataset.correct === 'true') {
       showSuccess();
+      setMessage('Change confirmed. Signal ready to transmit.');
     } else {
       hideSuccess();
+      setMessage('That detail matches the baseline feed. Try another option.');
+    }
+  }
+
+  function setChecklistEnabled(enabled) {
+    if (state.fieldset) {
+      state.fieldset.disabled = !enabled;
+    }
+  }
+
+  function clearOptions() {
+    if (state.optionList) {
+      state.optionList.innerHTML = '';
+    }
+  }
+
+  function setMessage(message) {
+    if (state.progressMessage) {
+      state.progressMessage.textContent = message;
     }
   }
 
@@ -192,7 +240,7 @@
     if (state.successBanner) {
       state.successBanner.classList.remove('visible');
     }
-    if (state.keywordNode && !countFound()) {
+    if (state.keywordNode) {
       state.keywordNode.textContent = '';
     }
     if (global.SubControls && typeof global.SubControls.clearKeywordBanner === 'function') {
@@ -200,30 +248,29 @@
     }
   }
 
-  function handleMarkerClick(event) {
-    const target = event.currentTarget;
-    if (!target) {
-      return;
-    }
-
-    const diffId = target.dataset.differenceId;
-    const diff = diffId ? differenceMap.get(diffId) : null;
-    if (!diff) {
-      return;
-    }
-
-    diff.found = !diff.found;
-    setMarkerState(diff.id, diff.found);
-    updateProgress();
-  }
-
   function resetState() {
-    differences.forEach(diff => {
-      diff.found = false;
-      setMarkerState(diff.id, false);
-    });
     hideSuccess();
-    updateProgress();
+    state.currentChange = null;
+    setMessage('Press Observe to review the live feed.');
+
+    if (state.video) {
+      state.video.pause();
+      state.video.currentTime = 0;
+      state.video.hidden = false;
+    }
+
+    if (state.still) {
+      state.still.hidden = true;
+      state.still.removeAttribute('src');
+      state.still.setAttribute('alt', 'Still frame awaiting observation');
+    }
+
+    clearOptions();
+    setChecklistEnabled(false);
+
+    if (state.observeButton) {
+      state.observeButton.disabled = false;
+    }
   }
 
   function preparePuzzle() {
@@ -231,11 +278,7 @@
       return false;
     }
 
-    if (!state.initialised) {
-      buildMarkers();
-      state.initialised = true;
-    }
-
+    bindEvents();
     return true;
   }
 
@@ -243,6 +286,7 @@
     if (!preparePuzzle()) {
       return;
     }
+
     resetState();
   }
 
@@ -250,6 +294,7 @@
     if (!preparePuzzle()) {
       return;
     }
+
     resetState();
   }
 
@@ -258,12 +303,16 @@
       return;
     }
 
-    differences.forEach(diff => {
-      diff.found = true;
-      setMarkerState(diff.id, true);
-    });
+    if (!state.currentChange) {
+      displayRandomChange();
+    }
 
-    updateProgress();
+    const correctOption = state.optionList.querySelector("input[data-correct='true']");
+    if (correctOption) {
+      correctOption.checked = true;
+      showSuccess();
+      setMessage('Change confirmed. Signal ready to transmit.');
+    }
   }
 
   global.initializePortholePuzzle = initialisePuzzle;

--- a/style.css
+++ b/style.css
@@ -146,8 +146,14 @@ section.active {
   gap: 1.5rem;
 }
 
+.porthole-intro {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
 .porthole-intro h2 {
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.25rem;
 }
 
 .porthole-intro p {
@@ -155,341 +161,103 @@ section.active {
   color: rgba(202, 240, 248, 0.85);
 }
 
-.porthole-scenes {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1.5rem;
-  justify-content: center;
+.porthole-observe-button {
+  align-self: flex-start;
+  padding: 0.65rem 1.25rem;
+  border-radius: 999px;
+  border: 1px solid rgba(144, 224, 239, 0.6);
+  background: linear-gradient(135deg, rgba(0, 119, 182, 0.55), rgba(0, 180, 216, 0.35));
+  color: #caf0f8;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.porthole-scene {
-  flex: 1 1 240px;
-  max-width: 320px;
+.porthole-observe-button:hover,
+.porthole-observe-button:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 0 16px rgba(72, 202, 228, 0.4);
+  outline: none;
+}
+
+.porthole-viewer {
+  display: grid;
+  place-items: center;
+  gap: 1rem;
+  padding: 1rem;
+  border-radius: 1rem;
+  background: rgba(0, 119, 182, 0.18);
+  border: 1px solid rgba(72, 202, 228, 0.35);
+}
+
+.porthole-video,
+.porthole-still {
+  width: min(100%, 480px);
+  border-radius: 1rem;
+  box-shadow: 0 0 18px rgba(72, 202, 228, 0.3);
+}
+
+.porthole-video {
+  aspect-ratio: 16 / 9;
+  background: #03045e;
+}
+
+.porthole-still[hidden] {
+  display: none;
+}
+
+.porthole-checklist {
+  margin: 0;
+}
+
+.porthole-checklist fieldset {
+  border: 1px solid rgba(72, 202, 228, 0.35);
+  border-radius: 1rem;
+  padding: 1rem 1.25rem;
+  background: rgba(0, 53, 102, 0.3);
+}
+
+.porthole-checklist legend {
+  padding: 0 0.5rem;
+  font-weight: 600;
+  color: #ade8f4;
+}
+
+.porthole-option-list {
+  list-style: none;
+  margin: 0.75rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.porthole-option-list li {
   display: flex;
-  flex-direction: column;
   align-items: center;
   gap: 0.75rem;
 }
 
-.porthole-frame {
-  width: 100%;
-  padding: 0.85rem;
-  border-radius: 50%;
-  background: linear-gradient(145deg, rgba(0, 36, 82, 0.9), rgba(0, 119, 182, 0.45));
-  box-shadow: 0 0 18px rgba(0, 119, 182, 0.45);
-  position: relative;
+.porthole-option-list input[type='checkbox'] {
+  width: 1.1rem;
+  height: 1.1rem;
+  accent-color: #48cae4;
 }
 
-.porthole-frame::before {
-  content: '';
-  position: absolute;
-  inset: 0.5rem;
-  border-radius: 50%;
-  border: 2px solid rgba(72, 202, 228, 0.25);
-  pointer-events: none;
-}
-
-.porthole-glass {
-  position: relative;
-  width: 100%;
-  aspect-ratio: 1 / 1;
-  border-radius: 50%;
-  overflow: hidden;
-  border: 4px solid rgba(144, 224, 239, 0.45);
-  background: radial-gradient(circle at 25% 20%, rgba(144, 224, 239, 0.55), rgba(3, 4, 94, 0.9));
-  box-shadow: inset 0 0 30px rgba(1, 22, 39, 0.85), 0 0 18px rgba(72, 202, 228, 0.3);
-}
-
-.porthole-glass::after {
-  content: '';
-  position: absolute;
-  inset: 12%;
-  border-radius: 50%;
-  background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.12), transparent 65%);
-  pointer-events: none;
-}
-
-.porthole-label {
-  text-transform: uppercase;
-  letter-spacing: 0.08rem;
-  font-size: 0.95rem;
-  color: #90e0ef;
-}
-
-.porthole-glass .scene-detail {
-  position: absolute;
-}
-
-.porthole-glass .scene-detail.hull {
-  width: 76%;
-  height: 40%;
-  left: 50%;
-  bottom: 12%;
-  transform: translateX(-50%);
-  background: linear-gradient(180deg, rgba(3, 4, 94, 0.75), rgba(1, 22, 39, 0.95));
-  border-radius: 45% 45% 50% 50%;
-  border: 2px solid rgba(0, 36, 82, 0.85);
-  box-shadow: 0 0 18px rgba(0, 36, 82, 0.6);
-}
-
-.porthole-glass .scene-detail.tower {
-  width: 22%;
-  height: 26%;
-  left: 50%;
-  bottom: 48%;
-  transform: translateX(-50%);
-  background: linear-gradient(180deg, rgba(144, 224, 239, 0.9), rgba(0, 96, 150, 0.6));
-  border-radius: 45% 45% 8% 8%;
-  box-shadow: 0 0 12px rgba(72, 202, 228, 0.55);
-}
-
-.porthole-glass .scene-detail.tower::after {
-  content: '';
-  position: absolute;
-  width: 24%;
-  height: 65%;
-  right: 14%;
-  top: -55%;
-  background: rgba(202, 240, 248, 0.8);
-  border-radius: 50% 50% 35% 35%;
-  box-shadow: 0 0 10px rgba(173, 232, 244, 0.7);
-}
-
-.porthole-glass .scene-detail.viewport {
-  width: 12%;
-  height: 12%;
-  bottom: 22%;
-  border-radius: 50%;
-  background: radial-gradient(circle at 35% 35%, rgba(202, 240, 248, 0.95), rgba(0, 119, 182, 0.55));
-  border: 2px solid rgba(173, 232, 244, 0.7);
-  box-shadow: 0 0 10px rgba(72, 202, 228, 0.5);
-}
-
-.porthole-glass .scene-detail.viewport.viewport-a {
-  left: 32%;
-}
-
-.porthole-glass .scene-detail.viewport.viewport-b {
-  left: 50%;
-  transform: translateX(-50%);
-}
-
-.porthole-glass .scene-detail.viewport.viewport-c {
-  left: 68%;
-}
-
-[data-scene='starboard'] .scene-detail.viewport.viewport-c {
-  display: none;
-}
-
-.porthole-glass .scene-detail.buoy {
-  width: 18%;
-  height: 18%;
-  top: 24%;
-  left: 28%;
-  border-radius: 50%;
-  background: radial-gradient(circle at 35% 30%, rgba(202, 240, 248, 0.9), rgba(0, 119, 182, 0.6));
-  box-shadow: 0 0 12px rgba(144, 224, 239, 0.6);
-}
-
-.porthole-glass .scene-detail.buoy::before {
-  content: '';
-  position: absolute;
-  width: 3px;
-  height: 180%;
-  top: -110%;
-  left: 50%;
-  transform: translateX(-50%);
-  background: rgba(173, 232, 244, 0.85);
-  border-radius: 2px;
-}
-
-.porthole-glass .scene-detail.buoy::after {
-  content: '';
-  position: absolute;
-  left: calc(50% + 2px);
-  top: -122%;
-  border-style: solid;
-  border-width: 8px 0 8px 13px;
-  border-color: transparent transparent transparent rgba(72, 202, 228, 0.9);
-}
-
-[data-scene='starboard'] .scene-detail.buoy::after {
-  border-left-color: transparent;
-}
-
-.porthole-glass .scene-detail.kelp {
-  width: 10%;
-  bottom: 8%;
-  background: linear-gradient(180deg, rgba(72, 202, 228, 0.9), rgba(0, 36, 82, 0.35));
-  border-radius: 50% 50% 0 0;
-  box-shadow: 0 0 14px rgba(72, 202, 228, 0.35);
-}
-
-.porthole-glass .scene-detail.kelp::after {
-  content: '';
-  position: absolute;
-  width: 140%;
-  height: 55%;
-  left: 50%;
-  bottom: 25%;
-  transform: translateX(-50%) rotate(12deg);
-  border-radius: 45% 45% 20% 20%;
-  background: rgba(144, 224, 239, 0.35);
-}
-
-.porthole-glass .scene-detail.kelp.kelp-port {
-  left: 14%;
-  height: 48%;
-}
-
-.porthole-glass .scene-detail.kelp.kelp-starboard {
-  right: 14%;
-  height: 55%;
-}
-
-[data-scene='starboard'] .scene-detail.kelp.kelp-starboard {
-  height: 34%;
-}
-
-.porthole-glass .scene-detail.jellyfish {
-  width: 24%;
-  height: 18%;
-  top: 34%;
-  right: 16%;
-  border-radius: 50% 50% 60% 60%;
-  background: radial-gradient(circle at 50% 35%, rgba(173, 232, 244, 0.85), rgba(0, 119, 182, 0.25));
-  box-shadow: 0 0 14px rgba(144, 224, 239, 0.55);
-  opacity: 0.95;
-}
-
-.porthole-glass .scene-detail.jellyfish::after {
-  content: '';
-  position: absolute;
-  bottom: -45%;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 75%;
-  height: 65%;
-  border-radius: 50% 50% 70% 70%;
-  background: radial-gradient(circle, rgba(173, 232, 244, 0.5), transparent 70%);
-  filter: blur(2px);
-}
-
-[data-scene='port'] .scene-detail.jellyfish {
-  opacity: 0;
-  pointer-events: none;
-}
-
-.porthole-glass .scene-detail.sonar {
-  width: 58%;
-  height: 58%;
-  top: 18%;
-  left: 50%;
-  transform: translateX(-50%);
-  border-radius: 50%;
-  border: 2px solid rgba(144, 224, 239, 0.35);
-  box-shadow: 0 0 18px rgba(72, 202, 228, 0.35);
-  opacity: 0.35;
-}
-
-.porthole-glass .scene-detail.sonar::after {
-  content: '';
-  position: absolute;
-  inset: 14%;
-  border-radius: 50%;
-  border: 2px solid rgba(72, 202, 228, 0.25);
-  animation: sonarPulse 5.5s linear infinite;
-}
-
-[data-scene='starboard'] .scene-detail.sonar {
-  opacity: 0;
-  pointer-events: none;
-}
-
-.porthole-glass .scene-detail.bubbles {
-  width: 6%;
-  height: 6%;
-  border-radius: 50%;
-  background: rgba(173, 232, 244, 0.85);
-  box-shadow: 0 0 12px rgba(144, 224, 239, 0.45);
-  opacity: 0.85;
-}
-
-.porthole-glass .scene-detail.bubbles::before,
-.porthole-glass .scene-detail.bubbles::after {
-  content: '';
-  position: absolute;
-  border-radius: 50%;
-  background: rgba(173, 232, 244, 0.65);
-}
-
-.porthole-glass .scene-detail.bubbles::before {
-  width: 75%;
-  height: 75%;
-  left: -55%;
-  top: -25%;
-}
-
-.porthole-glass .scene-detail.bubbles::after {
-  width: 50%;
-  height: 50%;
-  right: -45%;
-  bottom: 10%;
-  opacity: 0.85;
-}
-
-.porthole-glass .scene-detail.bubbles.cluster-one {
-  left: 22%;
-  bottom: 38%;
-}
-
-.porthole-glass .scene-detail.bubbles.cluster-two {
-  left: 30%;
-  bottom: 24%;
-}
-
-[data-scene='starboard'] .scene-detail.bubbles.cluster-two {
-  opacity: 0;
-  pointer-events: none;
-}
-
-.difference-marker {
-  position: absolute;
-  width: 2.75rem;
-  height: 2.75rem;
-  transform: translate(-50%, -50%);
-  border-radius: 50%;
-  border: 2px dashed rgba(173, 232, 244, 0.7);
-  background: rgba(0, 119, 182, 0.18);
-  box-shadow: 0 0 10px rgba(72, 202, 228, 0.3);
+.porthole-option-list label {
+  flex: 1;
   cursor: pointer;
-  padding: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  opacity: 0.55;
-  transition: opacity 0.25s ease, background 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease;
-  color: transparent;
+  color: rgba(202, 240, 248, 0.9);
 }
 
-.difference-marker:hover,
-.difference-marker:focus {
-  opacity: 1;
-  border-style: solid;
-  border-color: rgba(144, 224, 239, 0.95);
-  background: rgba(0, 119, 182, 0.35);
-  box-shadow: 0 0 16px rgba(72, 202, 228, 0.65);
-  outline: none;
-}
+@media (max-width: 720px) {
+  .porthole-viewer {
+    padding: 0.75rem;
+  }
 
-.difference-marker.found {
-  opacity: 1;
-  border-style: solid;
-  border-color: rgba(72, 202, 228, 0.95);
-  background: rgba(72, 202, 228, 0.9);
-  box-shadow: 0 0 18px rgba(144, 224, 239, 0.8);
-  color: #03045e;
+  .porthole-checklist fieldset {
+    padding: 0.85rem 1rem;
+  }
 }
 
 .porthole-progress {
@@ -539,31 +307,6 @@ section.active {
   color: #48cae4;
   text-transform: uppercase;
   text-shadow: 0 0 18px rgba(72, 202, 228, 0.7);
-}
-
-@keyframes sonarPulse {
-  0% {
-    transform: scale(0.85);
-    opacity: 0.4;
-  }
-  70% {
-    opacity: 0.9;
-  }
-  100% {
-    transform: scale(1.25);
-    opacity: 0;
-  }
-}
-
-@media (max-width: 720px) {
-  .porthole-scenes {
-    flex-direction: column;
-    align-items: center;
-  }
-
-  .porthole-frame {
-    max-width: 240px;
-  }
 }
 
 .peg {

--- a/tests/e2e/porthole.spec.js
+++ b/tests/e2e/porthole.spec.js
@@ -1,22 +1,23 @@
 const { test, expect } = require('@playwright/test');
 
-test('porthole puzzle reveals keyword after marking all differences', async ({ page }) => {
+test('porthole puzzle reveals keyword after logging the correct change', async ({ page }) => {
   await page.goto('/');
   await page.click('nav .tab[data-target="spot-diff"]');
 
-  await page.waitForSelector('.difference-marker');
+  await page.click('#porthole-observe-button');
 
-  const differenceIds = await page.evaluate(() => {
-    return Array.from(
-      new Set(
-        Array.from(document.querySelectorAll('.difference-marker')).map(el => el.dataset.differenceId)
-      )
-    ).filter(Boolean);
+  await page.evaluate(() => {
+    const video = document.querySelector('#porthole-video');
+    if (video) {
+      video.pause();
+      video.dispatchEvent(new Event('ended'));
+    }
   });
 
-  for (const id of differenceIds) {
-    await page.locator(`.difference-marker[data-difference-id="${id}"]`).first().click();
-  }
+  await page.waitForSelector('#porthole-option-list li');
+  const correctOption = page.locator("#porthole-option-list input[data-correct='true']");
+  await expect(correctOption).toHaveCount(1);
+  await correctOption.check();
 
   const successBanner = page.locator('#porthole-success');
   await expect(successBanner).toHaveClass(/visible/);


### PR DESCRIPTION
## Summary
- replace the spot-the-difference layout with an observe button that plays the baseline video before revealing a random still frame with placeholder change options
- add simplified styling for the new viewer and checklist interface while updating related copy to describe the observation flow
- update the Playwright spec to select the logged change instead of clicking difference markers

## Testing
- npm run test:e2e *(fails: Playwright browsers not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ec0bfd15d08325a68a17bc3b4f8e44