### PR TITLE
Simplify ballast controls and clarify lever effects

### DIFF
--- a/ballast.js
+++ b/ballast.js
@@ -3,14 +3,14 @@
     return;
   }
 
-  const BALLAST_OFFSET_BASE = 2;
-  const BALLAST_OFFSET_MIN = -2;
-  const BALLAST_OFFSET_MAX = 2;
+  const BALLAST_OFFSET_BASE = 1;
+  const BALLAST_OFFSET_MIN = -1;
+  const BALLAST_OFFSET_MAX = 1;
 
   const ballastConfig = {
-    baseTilt: -10,
-    baseDepth: -8,
-    maxMoves: 7,
+    baseTilt: 2,
+    baseDepth: 6,
+    maxMoves: 5,
     gaugeRange: 18,
     gaugeDegrees: 65,
     keyword: 'TRIM',
@@ -139,7 +139,8 @@
         const config = ballastLevers.find(lever => lever.id === leverId);
         if (!config) return null;
         const valueDisplay = wrapper.querySelector('.lever-value');
-        return { slider, valueDisplay, config };
+        const hintDisplay = wrapper.querySelector('.lever-hint');
+        return { slider, valueDisplay, hintDisplay, config };
       })
       .filter(Boolean);
 
@@ -149,6 +150,8 @@
         showPendingBallastMessage();
       });
     });
+
+    updateLeverHints();
 
     ballastElements.toggleButton?.addEventListener('click', toggleBallastPolarity);
     ballastElements.confirmButton?.addEventListener('click', commitBallastAdjustment);
@@ -212,8 +215,43 @@
     ballastElements.levers.forEach(({ slider, valueDisplay }) => {
       if (!valueDisplay) return;
       const offset = sliderValueToOffset(slider.value);
-      valueDisplay.textContent = offset > 0 ? `+${offset}` : `${offset}`;
+      if (offset === 0) {
+        valueDisplay.textContent = 'Neutral';
+        return;
+      }
+
+      const direction = offset > 0 ? 'Flood' : 'Vent';
+      const formatted = offset > 0 ? `+${offset}` : `${offset}`;
+      valueDisplay.textContent = `${direction} ${formatted}`;
     });
+  }
+
+  function updateLeverHints() {
+    ballastElements.levers.forEach(({ hintDisplay, config }) => {
+      if (!hintDisplay) return;
+      hintDisplay.textContent = describeLeverEffect(config);
+    });
+  }
+
+  function describeLeverEffect(config) {
+    const parts = [];
+
+    if (config.tilt === 0) {
+      parts.push('keeps trim level');
+    } else {
+      const tiltDirection = config.tilt > 0 ? 'starboard' : 'port';
+      parts.push(`lists ${Math.abs(config.tilt)}° to the ${tiltDirection}`);
+    }
+
+    if (config.depth === 0) {
+      parts.push('holds depth steady');
+    } else {
+      const depthDirection = config.depth > 0 ? 'sinks' : 'rises';
+      parts.push(`${depthDirection} ${Math.abs(config.depth)}m`);
+    }
+
+    const effect = parts.join(' and ');
+    return `Flooding ${effect} per notch. Venting reverses the effect.`;
   }
 
   function showPendingBallastMessage() {

--- a/index.html
+++ b/index.html
@@ -200,6 +200,7 @@
       <div>
         <h2>⚖️ Ballast Balance</h2>
         <p>Trim the submarine by tuning the ballast levers. Use the polarity switch to vent or flood tanks, then lock in your adjustments before alarms overwhelm the crew.</p>
+        <p class="ballast-helper">Each dial explains what flooding a notch will do—venting has the opposite effect.</p>
       </div>
       <div class="ballast-body">
         <div class="ballast-controls">
@@ -208,37 +209,41 @@
               <div class="lever-title">Bow Flood</div>
               <div class="lever-track">
                 <span class="lever-stop">VENT</span>
-                <input type="range" min="0" max="4" value="2" />
+                <input type="range" min="0" max="2" value="1" />
                 <span class="lever-stop">FLOOD</span>
               </div>
-              <div class="lever-readout">Trim shift: <span class="lever-value">0</span></div>
+              <div class="lever-readout">Setting: <span class="lever-value">Neutral</span></div>
+              <div class="lever-hint"></div>
             </div>
             <div class="ballast-lever" data-lever="stern">
               <div class="lever-title">Stern Pumps</div>
               <div class="lever-track">
                 <span class="lever-stop">VENT</span>
-                <input type="range" min="0" max="4" value="2" />
+                <input type="range" min="0" max="2" value="1" />
                 <span class="lever-stop">FLOOD</span>
               </div>
-              <div class="lever-readout">Trim shift: <span class="lever-value">0</span></div>
+              <div class="lever-readout">Setting: <span class="lever-value">Neutral</span></div>
+              <div class="lever-hint"></div>
             </div>
             <div class="ballast-lever" data-lever="port">
               <div class="lever-title">Port Trim</div>
               <div class="lever-track">
                 <span class="lever-stop">VENT</span>
-                <input type="range" min="0" max="4" value="2" />
+                <input type="range" min="0" max="2" value="1" />
                 <span class="lever-stop">FLOOD</span>
               </div>
-              <div class="lever-readout">Trim shift: <span class="lever-value">0</span></div>
+              <div class="lever-readout">Setting: <span class="lever-value">Neutral</span></div>
+              <div class="lever-hint"></div>
             </div>
             <div class="ballast-lever" data-lever="starboard">
               <div class="lever-title">Starboard Trim</div>
               <div class="lever-track">
                 <span class="lever-stop">VENT</span>
-                <input type="range" min="0" max="4" value="2" />
+                <input type="range" min="0" max="2" value="1" />
                 <span class="lever-stop">FLOOD</span>
               </div>
-              <div class="lever-readout">Trim shift: <span class="lever-value">0</span></div>
+              <div class="lever-readout">Setting: <span class="lever-value">Neutral</span></div>
+              <div class="lever-hint"></div>
             </div>
           </div>
           <div class="ballast-actions">

--- a/style.css
+++ b/style.css
@@ -745,6 +745,12 @@ section.active {
   z-index: 1;
 }
 
+.ballast-helper {
+  margin-top: 0.75rem;
+  font-size: 0.95rem;
+  color: rgba(202, 240, 248, 0.75);
+}
+
 .ballast-body {
   display: flex;
   flex-wrap: wrap;
@@ -854,6 +860,14 @@ section.active {
   color: #ffd166;
   font-weight: 700;
   margin-left: 0.25rem;
+}
+
+.lever-hint {
+  margin-top: 0.4rem;
+  font-size: 0.75rem;
+  line-height: 1.3;
+  color: rgba(202, 240, 248, 0.65);
+  text-align: center;
 }
 
 .ballast-actions {


### PR DESCRIPTION
## Summary
- retune the ballast puzzle with a narrower slider range and updated base trim for a simpler solution path
- refresh the lever readouts to show "Neutral", "Flood", or "Vent" settings
- add in-panel copy and lever hints that explain how flooding affects trim and depth

## Testing
- npm run test:e2e *(fails: Playwright browsers unavailable in environment)*
- npx playwright install --with-deps *(fails: apt repositories blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68ec0d6a0e848325a04f9bf75e4e1ec3